### PR TITLE
feat: add PDF preview and export for CRA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@react-pdf/renderer": "^4.3.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.552.0",
         "react": "^18.3.1",
@@ -287,6 +288,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1088,6 +1098,180 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@react-pdf/fns": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@react-pdf/fns/-/fns-3.1.2.tgz",
+      "integrity": "sha512-qTKGUf0iAMGg2+OsUcp9ffKnKi41RukM/zYIWMDJ4hRVYSr89Q7e3wSDW/Koqx3ea3Uy/z3h2y3wPX6Bdfxk6g==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/font": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/font/-/font-4.0.3.tgz",
+      "integrity": "sha512-N1qQDZr6phXYQOp033Hvm2nkUkx2LkszjGPbmRavs9VOYzi4sp31MaccMKptL24ii6UhBh/z9yPUhnuNe/qHwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/pdfkit": "^4.0.4",
+        "@react-pdf/types": "^2.9.1",
+        "fontkit": "^2.0.2",
+        "is-url": "^1.2.4"
+      }
+    },
+    "node_modules/@react-pdf/image": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@react-pdf/image/-/image-3.0.3.tgz",
+      "integrity": "sha512-lvP5ryzYM3wpbO9bvqLZYwEr5XBDX9jcaRICvtnoRqdJOo7PRrMnmB4MMScyb+Xw10mGeIubZAAomNAG5ONQZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/png-js": "^3.0.0",
+        "jay-peg": "^1.1.1"
+      }
+    },
+    "node_modules/@react-pdf/layout": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/layout/-/layout-4.4.1.tgz",
+      "integrity": "sha512-GVzdlWoZWldRDzlWj3SttRXmVDxg7YfraAohwy+o9gb9hrbDJaaAV6jV3pc630Evd3K46OAzk8EFu8EgPDuVuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/image": "^3.0.3",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/stylesheet": "^6.1.1",
+        "@react-pdf/textkit": "^6.0.0",
+        "@react-pdf/types": "^2.9.1",
+        "emoji-regex-xs": "^1.0.0",
+        "queue": "^6.0.1",
+        "yoga-layout": "^3.2.1"
+      }
+    },
+    "node_modules/@react-pdf/pdfkit": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@react-pdf/pdfkit/-/pdfkit-4.0.4.tgz",
+      "integrity": "sha512-/nITLggsPlB66bVLnm0X7MNdKQxXelLGZG6zB5acF5cCgkFwmXHnLNyxYOUD4GMOMg1HOPShXDKWrwk2ZeHsvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/png-js": "^3.0.0",
+        "browserify-zlib": "^0.2.0",
+        "crypto-js": "^4.2.0",
+        "fontkit": "^2.0.2",
+        "jay-peg": "^1.1.1",
+        "linebreak": "^1.1.0",
+        "vite-compatible-readable-stream": "^3.6.1"
+      }
+    },
+    "node_modules/@react-pdf/png-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/png-js/-/png-js-3.0.0.tgz",
+      "integrity": "sha512-eSJnEItZ37WPt6Qv5pncQDxLJRK15eaRwPT+gZoujP548CodenOVp49GST8XJvKMFt9YqIBzGBV/j9AgrOQzVA==",
+      "license": "MIT",
+      "dependencies": {
+        "browserify-zlib": "^0.2.0"
+      }
+    },
+    "node_modules/@react-pdf/primitives": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/primitives/-/primitives-4.1.1.tgz",
+      "integrity": "sha512-IuhxYls1luJb7NUWy6q5avb1XrNaVj9bTNI40U9qGRuS6n7Hje/8H8Qi99Z9UKFV74bBP3DOf3L1wV2qZVgVrQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/reconciler": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@react-pdf/reconciler/-/reconciler-1.1.4.tgz",
+      "integrity": "sha512-oTQDiR/t4Z/Guxac88IavpU2UgN7eR0RMI9DRKvKnvPz2DUasGjXfChAdMqDNmJJxxV26mMy9xQOUV2UU5/okg==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "scheduler": "0.25.0-rc-603e6108-20241029"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/reconciler/node_modules/scheduler": {
+      "version": "0.25.0-rc-603e6108-20241029",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
+      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "license": "MIT"
+    },
+    "node_modules/@react-pdf/render": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/render/-/render-4.3.1.tgz",
+      "integrity": "sha512-v1WAaAhQShQZGcBxfjkEThGCHVH9CSuitrZ1bIOLvB5iBKM14abYK5D6djKhWCwF6FTzYeT2WRjRMVgze/ND2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/textkit": "^6.0.0",
+        "@react-pdf/types": "^2.9.1",
+        "abs-svg-path": "^0.1.1",
+        "color-string": "^1.9.1",
+        "normalize-svg-path": "^1.1.0",
+        "parse-svg-path": "^0.1.2",
+        "svg-arc-to-cubic-bezier": "^3.2.0"
+      }
+    },
+    "node_modules/@react-pdf/renderer": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/renderer/-/renderer-4.3.1.tgz",
+      "integrity": "sha512-dPKHiwGTaOsKqNWCHPYYrx8CDfAGsUnV4tvRsEu0VPGxuot1AOq/M+YgfN/Pb+MeXCTe2/lv6NvA8haUtj3tsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/font": "^4.0.3",
+        "@react-pdf/layout": "^4.4.1",
+        "@react-pdf/pdfkit": "^4.0.4",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/reconciler": "^1.1.4",
+        "@react-pdf/render": "^4.3.1",
+        "@react-pdf/types": "^2.9.1",
+        "events": "^3.3.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "queue": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@react-pdf/stylesheet": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/stylesheet/-/stylesheet-6.1.1.tgz",
+      "integrity": "sha512-Iyw0A3wRIeQLN4EkaKf8yF9MvdMxiZ8JjoyzLzDHSxnKYoOA4UGu84veCb8dT9N8MxY5x7a0BUv/avTe586Plg==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.2",
+        "@react-pdf/types": "^2.9.1",
+        "color-string": "^1.9.1",
+        "hsl-to-hex": "^1.0.0",
+        "media-engine": "^1.0.3",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "node_modules/@react-pdf/textkit": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@react-pdf/textkit/-/textkit-6.0.0.tgz",
+      "integrity": "sha512-fDt19KWaJRK/n2AaFoVm31hgGmpygmTV7LsHGJNGZkgzXcFyLsx+XUl63DTDPH3iqxj3xUX128t104GtOz8tTw==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/fns": "3.1.2",
+        "bidi-js": "^1.0.2",
+        "hyphen": "^1.6.4",
+        "unicode-properties": "^1.4.1"
+      }
+    },
+    "node_modules/@react-pdf/types": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@react-pdf/types/-/types-2.9.1.tgz",
+      "integrity": "sha512-5GoCgG0G5NMgpPuHbKG2xcVRQt7+E5pg3IyzVIIozKG3nLcnsXW4zy25vG1ZBQA0jmo39q34au/sOnL/0d1A4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-pdf/font": "^4.0.3",
+        "@react-pdf/primitives": "^4.1.1",
+        "@react-pdf/stylesheet": "^6.1.1"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1408,6 +1592,15 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
+      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.16",
@@ -2072,6 +2265,12 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/abs-svg-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
+      "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2181,6 +2380,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.23",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.23.tgz",
@@ -2189,6 +2408,15 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2213,6 +2441,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
+    "node_modules/browserify-zlib": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+      "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~1.0.5"
       }
     },
     "node_modules/browserslist": {
@@ -2298,6 +2544,15 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2324,8 +2579,17 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2364,6 +2628,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -2407,12 +2677,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.244",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.244.tgz",
       "integrity": "sha512-OszpBN7xZX4vWMPJwB9illkN/znA8M36GQqQxi6MNy9axWxhOfJyZZJtSLQCpEFLHP2xK33BiWx9aIuIEXVCcw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.18.3",
@@ -2687,11 +2969,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -2812,6 +3102,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -2901,6 +3208,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/hsl-to-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/hsl-to-hex/-/hsl-to-hex-1.0.0.tgz",
+      "integrity": "sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==",
+      "license": "MIT",
+      "dependencies": {
+        "hsl-to-rgb-for-reals": "^1.1.0"
+      }
+    },
+    "node_modules/hsl-to-rgb-for-reals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hsl-to-rgb-for-reals/-/hsl-to-rgb-for-reals-1.1.1.tgz",
+      "integrity": "sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==",
+      "license": "ISC"
+    },
+    "node_modules/hyphen": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/hyphen/-/hyphen-1.10.6.tgz",
+      "integrity": "sha512-fXHXcGFTXOvZTSkPJuGOQf5Lv5T/R2itiiCVPg9LxAje5D00O0pP83yJShFq5V89Ly//Gt6acj7z8pbBr34stw==",
+      "license": "ISC"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2938,6 +3266,18 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2971,12 +3311,27 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jay-peg": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jay-peg/-/jay-peg-1.1.1.tgz",
+      "integrity": "sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==",
+      "license": "MIT",
+      "dependencies": {
+        "restructure": "^3.0.0"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -3339,6 +3694,25 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/linebreak": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+      "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "0.0.8",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/linebreak/node_modules/base64-js": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3402,6 +3776,12 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/media-engine": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/media-engine/-/media-engine-1.0.3.tgz",
+      "integrity": "sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==",
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -3490,6 +3870,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-svg-path": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
+      "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
+      "license": "MIT",
+      "dependencies": {
+        "svg-arc-to-cubic-bezier": "^3.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3540,6 +3938,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3552,6 +3956,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-svg-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
+      "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -3627,7 +4037,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -3656,6 +4065,17 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3664,6 +4084,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {
@@ -3731,6 +4160,12 @@
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3779,6 +4214,15 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3788,6 +4232,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -3866,6 +4316,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -3914,6 +4384,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3922,6 +4401,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3949,6 +4437,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/svg-arc-to-cubic-bezier": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
+      "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
+      "license": "ISC"
     },
     "node_modules/tailwind-merge": {
       "version": "3.3.1",
@@ -3980,6 +4474,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -4056,6 +4556,12 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -4115,6 +4621,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.4.tgz",
@@ -4155,6 +4687,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.4.1",
@@ -4230,6 +4768,20 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-compatible-readable-stream": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/vite-compatible-readable-stream/-/vite-compatible-readable-stream-3.6.1.tgz",
+      "integrity": "sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/vite/node_modules/fdir": {
@@ -4309,6 +4861,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/zod": {
       "version": "4.1.12",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@react-pdf/renderer": "^4.3.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.552.0",
     "react": "^18.3.1",

--- a/src/components/pdf/CRAPDFDocument.tsx
+++ b/src/components/pdf/CRAPDFDocument.tsx
@@ -1,0 +1,110 @@
+/**
+ * Document PDF complet pour un CRA
+ *
+ * Assemble tous les composants PDF pour générer un compte rendu
+ * d'activité professionnel sur une seule page A4.
+ *
+ * @example
+ * ```tsx
+ * import { pdf } from '@react-pdf/renderer';
+ * import { CRAPDFDocument } from '@/components/pdf';
+ *
+ * const blob = await pdf(
+ *   <CRAPDFDocument cra={cra} clientCompany={client} providerCompany={provider} />
+ * ).toBlob();
+ * ```
+ */
+
+import { Document, Page, Text } from '@react-pdf/renderer';
+import { pdfStyles } from './pdfStyles';
+import { PDFHeader } from './PDFHeader';
+import { PDFInfoSection } from './PDFInfoSection';
+import { PDFCalendarGrid } from './PDFCalendarGrid';
+import { PDFSummary } from './PDFSummary';
+import { PDFComment } from './PDFComment';
+import { PDFSignatures } from './PDFSignatures';
+import type { CRA } from '@/types/cra.types';
+import type { Company } from '@/types/company.types';
+
+interface CRAPDFDocumentProps {
+  /** Données du CRA */
+  cra: CRA;
+  /** Société cliente */
+  clientCompany: Company;
+  /** Société prestataire */
+  providerCompany: Company;
+}
+
+/**
+ * Document PDF CRA complet
+ *
+ * Structure du document :
+ * - En-tête avec titre
+ * - Bandeau période
+ * - Informations des sociétés (2 colonnes)
+ * - Calendrier avec jours travaillés
+ * - Résumé (total jours)
+ * - Commentaire (optionnel)
+ * - Signatures
+ * - Footer avec date de génération
+ */
+export function CRAPDFDocument({
+  cra,
+  clientCompany,
+  providerCompany,
+}: CRAPDFDocumentProps) {
+  const workedDaysCount = cra.worked_days?.length || 0;
+
+  // Récupérer les signatures (CRA override ou défaut company)
+  const clientSignature = {
+    name: cra.client_signatory_name || clientCompany.default_signatory_name,
+    title: cra.client_signatory_title || clientCompany.default_signatory_title,
+    image: cra.client_signature_image || clientCompany.default_signature_image,
+  };
+
+  const providerSignature = {
+    name: cra.provider_signatory_name || providerCompany.default_signatory_name,
+    title: cra.provider_signatory_title || providerCompany.default_signatory_title,
+    image: cra.provider_signature_image || providerCompany.default_signature_image,
+  };
+
+  return (
+    <Document
+      title={`CRA - ${providerCompany.designation} - ${clientCompany.designation}`}
+      author={providerCompany.designation}
+      subject={`Compte Rendu d'Activité - ${cra.month}/${cra.year}`}
+    >
+      <Page size="A4" style={pdfStyles.page}>
+        <PDFHeader />
+
+        <PDFInfoSection
+          providerCompany={providerCompany}
+          clientCompany={clientCompany}
+          month={cra.month}
+          year={cra.year}
+        />
+
+        <PDFCalendarGrid
+          month={cra.month}
+          year={cra.year}
+          workedDays={cra.worked_days || []}
+        />
+
+        <PDFSummary workedDaysCount={workedDaysCount} />
+
+        {cra.comment && <PDFComment comment={cra.comment} />}
+
+        <PDFSignatures
+          clientCompanyName={clientCompany.designation}
+          providerCompanyName={providerCompany.designation}
+          clientSignature={clientSignature}
+          providerSignature={providerSignature}
+        />
+
+        <Text style={pdfStyles.footer}>
+          Document généré automatiquement - {new Date().toLocaleDateString('fr-FR')}
+        </Text>
+      </Page>
+    </Document>
+  );
+}

--- a/src/components/pdf/PDFCalendarGrid.tsx
+++ b/src/components/pdf/PDFCalendarGrid.tsx
@@ -1,0 +1,97 @@
+/**
+ * Grille calendrier du PDF CRA
+ *
+ * Affiche un calendrier mensuel avec les jours travaillés mis en évidence.
+ * La semaine commence le lundi.
+ */
+
+import { View, Text } from '@react-pdf/renderer';
+import type { Style } from '@react-pdf/types';
+import { pdfStyles } from './pdfStyles';
+import { getCalendarGridMondayFirst, WEEKDAYS_MONDAY_FIRST } from '@/lib/monthUtils';
+
+interface PDFCalendarGridProps {
+  /** Mois du calendrier (1-12) */
+  month: number;
+  /** Année du calendrier */
+  year: number;
+  /** Liste des jours travaillés */
+  workedDays: number[];
+}
+
+/**
+ * Grille calendrier avec jours travaillés et weekends différenciés
+ */
+export function PDFCalendarGrid({
+  month,
+  year,
+  workedDays,
+}: PDFCalendarGridProps) {
+  const grid = getCalendarGridMondayFirst(month, year);
+  const workedDaysSet = new Set(workedDays);
+
+  /**
+   * Calcule les styles de la cellule en fonction de son état
+   */
+  const getCellStyle = (isWeekend: boolean, isWorked: boolean): Style[] => {
+    const styles: Style[] = [pdfStyles.dayCell];
+    if (isWeekend) styles.push(pdfStyles.dayCellWeekend);
+    if (isWorked) styles.push(pdfStyles.dayCellWorked);
+    return styles;
+  };
+
+  /**
+   * Calcule les styles du texte en fonction de son état
+   */
+  const getTextStyle = (isWeekend: boolean, isWorked: boolean): Style[] => {
+    const styles: Style[] = [pdfStyles.dayText];
+    if (isWeekend) styles.push(pdfStyles.dayTextWeekend);
+    if (isWorked) styles.push(pdfStyles.dayTextWorked);
+    return styles;
+  };
+
+  return (
+    <View style={pdfStyles.calendarSection}>
+      <View style={pdfStyles.calendarContainer}>
+        {/* En-tête des jours (Lun-Dim) */}
+        <View style={pdfStyles.weekHeader}>
+          {WEEKDAYS_MONDAY_FIRST.map((day) => (
+            <View key={day} style={pdfStyles.weekHeaderCell}>
+              <Text style={pdfStyles.weekHeaderText}>{day}</Text>
+            </View>
+          ))}
+        </View>
+
+        {/* Grille des jours */}
+        <View style={pdfStyles.calendarGrid}>
+          {grid.map((dayInfo, index) => {
+            if (!dayInfo) {
+              return <View key={`empty-${index}`} style={pdfStyles.dayCellEmpty} />;
+            }
+
+            const isWorked = workedDaysSet.has(dayInfo.day);
+            const isWeekend = dayInfo.isWeekend;
+
+            return (
+              <View key={dayInfo.day} style={getCellStyle(isWeekend, isWorked)}>
+                <Text style={getTextStyle(isWeekend, isWorked)}>{dayInfo.day}</Text>
+              </View>
+            );
+          })}
+        </View>
+      </View>
+
+      {/* Légende */}
+      <View style={pdfStyles.legend}>
+        <View style={pdfStyles.legendItem}>
+          <View style={[pdfStyles.legendBox, pdfStyles.legendBoxWorked]} />
+          <Text style={pdfStyles.legendText}>Jour travaillé</Text>
+        </View>
+        <View style={pdfStyles.legendItem}>
+          <View style={[pdfStyles.legendBox, pdfStyles.legendBoxWeekend]} />
+          <Text style={pdfStyles.legendText}>Week-end</Text>
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/src/components/pdf/PDFComment.tsx
+++ b/src/components/pdf/PDFComment.tsx
@@ -1,0 +1,27 @@
+/**
+ * Section commentaire du PDF CRA
+ *
+ * Affiche le commentaire optionnel du CRA dans un bloc stylisé.
+ */
+
+import { View, Text } from '@react-pdf/renderer';
+import { pdfStyles } from './pdfStyles';
+
+interface PDFCommentProps {
+  /** Texte du commentaire */
+  comment: string;
+}
+
+/**
+ * Composant affichant le commentaire du CRA
+ */
+export function PDFComment({ comment }: PDFCommentProps) {
+  return (
+    <View style={pdfStyles.commentSection}>
+      <Text style={pdfStyles.commentTitle}>Commentaire</Text>
+      <View style={pdfStyles.commentBox}>
+        <Text style={pdfStyles.commentText}>{comment}</Text>
+      </View>
+    </View>
+  );
+}

--- a/src/components/pdf/PDFHeader.tsx
+++ b/src/components/pdf/PDFHeader.tsx
@@ -1,0 +1,19 @@
+/**
+ * En-tête du document PDF CRA
+ *
+ * Affiche le titre "Compte Rendu d'Activité" avec le style DiscoData.
+ */
+
+import { View, Text } from '@react-pdf/renderer';
+import { pdfStyles } from './pdfStyles';
+
+/**
+ * Composant d'en-tête pour le PDF CRA
+ */
+export function PDFHeader() {
+  return (
+    <View style={pdfStyles.header}>
+      <Text style={pdfStyles.headerTitle}>Compte Rendu d'Activité</Text>
+    </View>
+  );
+}

--- a/src/components/pdf/PDFInfoSection.tsx
+++ b/src/components/pdf/PDFInfoSection.tsx
@@ -1,0 +1,111 @@
+/**
+ * Section informations du PDF CRA
+ *
+ * Affiche la période et les détails complets des sociétés
+ * (prestataire et client) en deux colonnes.
+ */
+
+import { View, Text } from '@react-pdf/renderer';
+import { pdfStyles } from './pdfStyles';
+import { formatMonthYear } from '@/lib/monthUtils';
+import type { Company } from '@/types/company.types';
+
+interface PDFInfoSectionProps {
+  /** Société prestataire */
+  providerCompany: Company;
+  /** Société cliente */
+  clientCompany: Company;
+  /** Mois du CRA (1-12) */
+  month: number;
+  /** Année du CRA */
+  year: number;
+}
+
+/**
+ * Formate l'adresse complète d'une société
+ */
+function formatAddress(company: Company): string {
+  const parts = [company.address];
+  if (company.complement) parts.push(company.complement);
+  parts.push(`${company.postal_code} ${company.city}`);
+  if (company.country && company.country !== 'France') {
+    parts.push(company.country);
+  }
+  return parts.join(', ');
+}
+
+/**
+ * Bloc détails d'une société
+ */
+function CompanyDetails({ company, label }: { company: Company; label: string }) {
+  return (
+    <View style={pdfStyles.companyBlock}>
+      <Text style={pdfStyles.companyHeader}>{label}</Text>
+      <Text style={pdfStyles.companyName}>{company.designation}</Text>
+
+      {/* Adresse */}
+      <Text style={pdfStyles.companyDetail}>{formatAddress(company)}</Text>
+
+      {/* Contact */}
+      <Text style={pdfStyles.companyDetail}>
+        {company.email}
+        {company.phone ? ` - ${company.phone}` : ''}
+      </Text>
+
+      {/* Identification (SIREN/SIRET) */}
+      <Text style={pdfStyles.companyDetail}>
+        <Text style={pdfStyles.companyDetailBold}>{company.repertoire} : </Text>
+        {company.repertoire_number}
+      </Text>
+
+      {/* Registre (si non dispensé) */}
+      {!company.dispense && company.registre && company.registre_number && (
+        <Text style={pdfStyles.companyDetail}>
+          <Text style={pdfStyles.companyDetailBold}>{company.registre} : </Text>
+          {company.registre_number}
+        </Text>
+      )}
+
+      {/* Code activité (NAF/APE) */}
+      {company.code && (
+        <Text style={pdfStyles.companyDetail}>
+          <Text style={pdfStyles.companyDetailBold}>{company.liste} : </Text>
+          {company.code}
+        </Text>
+      )}
+
+      {/* Numéro TVA (si non exempté) */}
+      {!company.exemption && company.tva_number && (
+        <Text style={pdfStyles.companyDetail}>
+          <Text style={pdfStyles.companyDetailBold}>TVA : </Text>
+          {company.tva_number}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+/**
+ * Section affichant la période et les informations des sociétés
+ */
+export function PDFInfoSection({
+  providerCompany,
+  clientCompany,
+  month,
+  year,
+}: PDFInfoSectionProps) {
+  return (
+    <View>
+      {/* Bandeau période */}
+      <View style={pdfStyles.periodBanner}>
+        <Text style={pdfStyles.periodText}>{formatMonthYear(month, year)}</Text>
+      </View>
+
+      {/* Sociétés côte à côte */}
+      <View style={pdfStyles.companiesSection}>
+        <CompanyDetails company={providerCompany} label="Prestataire" />
+        <CompanyDetails company={clientCompany} label="Client" />
+      </View>
+    </View>
+  );
+}

--- a/src/components/pdf/PDFSignatures.tsx
+++ b/src/components/pdf/PDFSignatures.tsx
@@ -1,0 +1,104 @@
+/**
+ * Section signatures du PDF CRA
+ *
+ * Affiche les blocs de signature pour le prestataire et le client,
+ * avec support des images de signature uploadées.
+ */
+
+import { View, Text, Image } from '@react-pdf/renderer';
+import { pdfStyles } from './pdfStyles';
+import { env } from '@/services/api';
+
+/** Informations de signature */
+interface SignatureInfo {
+  /** Nom du signataire */
+  name?: string;
+  /** Titre/fonction du signataire */
+  title?: string;
+  /** Chemin ou URL de l'image de signature */
+  image?: string;
+}
+
+interface PDFSignaturesProps {
+  /** Nom de la société cliente */
+  clientCompanyName: string;
+  /** Nom de la société prestataire */
+  providerCompanyName: string;
+  /** Signature du client */
+  clientSignature: SignatureInfo;
+  /** Signature du prestataire */
+  providerSignature: SignatureInfo;
+}
+
+/**
+ * Construit l'URL complète d'une image de signature
+ */
+function getSignatureImageUrl(path?: string): string | null {
+  if (!path) return null;
+  if (path.startsWith('http') || path.startsWith('data:')) return path;
+  const baseUrl = env.apiUrl?.replace('/api', '') || 'http://localhost:3001';
+  return `${baseUrl}${path}`;
+}
+
+/**
+ * Section avec les deux blocs de signature (prestataire et client)
+ */
+export function PDFSignatures({
+  clientCompanyName,
+  providerCompanyName,
+  clientSignature,
+  providerSignature,
+}: PDFSignaturesProps) {
+  const clientImageUrl = getSignatureImageUrl(clientSignature.image);
+  const providerImageUrl = getSignatureImageUrl(providerSignature.image);
+
+  return (
+    <View style={pdfStyles.signaturesSection}>
+      <Text style={pdfStyles.signaturesTitle}>Signatures</Text>
+
+      <View style={pdfStyles.signaturesRow}>
+        {/* Signature Prestataire */}
+        <View style={pdfStyles.signatureBlock}>
+          <Text style={pdfStyles.signatureLabel}>Pour le Prestataire</Text>
+          <Text style={pdfStyles.signatureCompany}>{providerCompanyName}</Text>
+
+          <View style={pdfStyles.signatureImageContainer}>
+            {providerImageUrl ? (
+              <Image src={providerImageUrl} style={pdfStyles.signatureImage} />
+            ) : (
+              <View style={pdfStyles.signaturePlaceholder} />
+            )}
+          </View>
+
+          {providerSignature.name && (
+            <Text style={pdfStyles.signatureName}>{providerSignature.name}</Text>
+          )}
+          {providerSignature.title && (
+            <Text style={pdfStyles.signatureTitle}>{providerSignature.title}</Text>
+          )}
+        </View>
+
+        {/* Signature Client */}
+        <View style={pdfStyles.signatureBlock}>
+          <Text style={pdfStyles.signatureLabel}>Pour le Client</Text>
+          <Text style={pdfStyles.signatureCompany}>{clientCompanyName}</Text>
+
+          <View style={pdfStyles.signatureImageContainer}>
+            {clientImageUrl ? (
+              <Image src={clientImageUrl} style={pdfStyles.signatureImage} />
+            ) : (
+              <View style={pdfStyles.signaturePlaceholder} />
+            )}
+          </View>
+
+          {clientSignature.name && (
+            <Text style={pdfStyles.signatureName}>{clientSignature.name}</Text>
+          )}
+          {clientSignature.title && (
+            <Text style={pdfStyles.signatureTitle}>{clientSignature.title}</Text>
+          )}
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/src/components/pdf/PDFSummary.tsx
+++ b/src/components/pdf/PDFSummary.tsx
@@ -1,0 +1,27 @@
+/**
+ * Section résumé du PDF CRA
+ *
+ * Affiche le total des jours travaillés dans un bandeau coloré.
+ */
+
+import { View, Text } from '@react-pdf/renderer';
+import { pdfStyles } from './pdfStyles';
+
+interface PDFSummaryProps {
+  /** Nombre de jours travaillés */
+  workedDaysCount: number;
+}
+
+/**
+ * Composant résumé affichant le total des jours travaillés
+ */
+export function PDFSummary({ workedDaysCount }: PDFSummaryProps) {
+  return (
+    <View style={pdfStyles.summarySection}>
+      <Text style={pdfStyles.summaryLabel}>Total des jours travaillés</Text>
+      <Text style={pdfStyles.summaryValue}>
+        {workedDaysCount} jour{workedDaysCount > 1 ? 's' : ''}
+      </Text>
+    </View>
+  );
+}

--- a/src/components/pdf/index.ts
+++ b/src/components/pdf/index.ts
@@ -1,0 +1,31 @@
+/**
+ * Composants PDF pour la génération de Comptes Rendus d'Activité
+ *
+ * @example
+ * ```tsx
+ * import { CRAPDFDocument } from '@/components/pdf';
+ * import { PDFViewer, pdf } from '@react-pdf/renderer';
+ *
+ * // Prévisualisation dans le navigateur
+ * <PDFViewer>
+ *   <CRAPDFDocument cra={cra} clientCompany={client} providerCompany={provider} />
+ * </PDFViewer>
+ *
+ * // Génération et téléchargement
+ * const blob = await pdf(<CRAPDFDocument ... />).toBlob();
+ * ```
+ */
+
+// Composant principal
+export { CRAPDFDocument } from './CRAPDFDocument';
+
+// Sous-composants (pour usage avancé)
+export { PDFHeader } from './PDFHeader';
+export { PDFInfoSection } from './PDFInfoSection';
+export { PDFCalendarGrid } from './PDFCalendarGrid';
+export { PDFSummary } from './PDFSummary';
+export { PDFComment } from './PDFComment';
+export { PDFSignatures } from './PDFSignatures';
+
+// Styles et couleurs
+export { pdfStyles, colors } from './pdfStyles';

--- a/src/components/pdf/pdfStyles.ts
+++ b/src/components/pdf/pdfStyles.ts
@@ -1,0 +1,376 @@
+/**
+ * Styles pour la génération de PDF des CRA
+ *
+ * Utilise @react-pdf/renderer StyleSheet avec une charte graphique
+ * inspirée du logo DiscoData (tons marron chocolat et orange doré).
+ *
+ * @see https://react-pdf.org/styling
+ */
+
+import { StyleSheet } from '@react-pdf/renderer';
+
+/**
+ * Palette de couleurs DiscoData
+ */
+const colors = {
+  // Couleurs principales
+  primary: '#5D4A3C', // Marron chocolat (vinyle)
+  primaryLight: '#7D6A5C',
+  accent: '#E08B2D', // Orange doré (DATA)
+  accentLight: '#F5A742',
+
+  // Texte
+  text: '#3D3028',
+  textSecondary: '#6D5D4D',
+  textLight: '#9D8D7D',
+
+  // Backgrounds
+  background: '#FAF7F4',
+  backgroundAlt: '#F5F0EB',
+  white: '#ffffff',
+
+  // Bordures
+  border: '#E5DDD5',
+  borderLight: '#F0EBE6',
+
+  // États calendrier
+  worked: '#FEF3E2',
+  workedText: '#B86B1D',
+  weekend: '#F5F0EB',
+  weekendText: '#8D7D6D',
+} as const;
+
+/**
+ * Styles PDF pour les composants CRA
+ */
+const pdfStyles = StyleSheet.create({
+  // ==========================================================================
+  // PAGE
+  // ==========================================================================
+  page: {
+    padding: 30,
+    fontFamily: 'Helvetica',
+    fontSize: 9,
+    color: colors.text,
+    backgroundColor: colors.white,
+  },
+
+  // ==========================================================================
+  // HEADER
+  // ==========================================================================
+  header: {
+    marginBottom: 15,
+    textAlign: 'center',
+    paddingBottom: 12,
+    borderBottomWidth: 3,
+    borderBottomColor: colors.accent,
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontFamily: 'Helvetica-Bold',
+    color: colors.primary,
+    textTransform: 'uppercase',
+    letterSpacing: 3,
+  },
+
+  // ==========================================================================
+  // SECTION SOCIÉTÉS
+  // ==========================================================================
+  companiesSection: {
+    flexDirection: 'row',
+    marginBottom: 12,
+    gap: 12,
+  },
+  companyBlock: {
+    flex: 1,
+    padding: 10,
+    backgroundColor: colors.background,
+    borderRadius: 6,
+    borderLeftWidth: 3,
+    borderLeftColor: colors.accent,
+  },
+  companyHeader: {
+    fontSize: 8,
+    fontFamily: 'Helvetica-Bold',
+    color: colors.accent,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 5,
+  },
+  companyName: {
+    fontSize: 11,
+    fontFamily: 'Helvetica-Bold',
+    color: colors.primary,
+    marginBottom: 4,
+  },
+  companyDetail: {
+    fontSize: 7.5,
+    color: colors.textSecondary,
+    marginBottom: 1.5,
+    lineHeight: 1.3,
+  },
+  companyDetailBold: {
+    fontFamily: 'Helvetica-Bold',
+    color: colors.text,
+  },
+
+  // ==========================================================================
+  // BANDEAU PÉRIODE
+  // ==========================================================================
+  periodBanner: {
+    backgroundColor: colors.primary,
+    padding: 10,
+    marginBottom: 12,
+    borderRadius: 6,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  periodText: {
+    fontSize: 14,
+    fontFamily: 'Helvetica-Bold',
+    color: colors.white,
+    textTransform: 'uppercase',
+    letterSpacing: 2,
+  },
+
+  // ==========================================================================
+  // CALENDRIER
+  // ==========================================================================
+  calendarSection: {
+    marginBottom: 10,
+  },
+  calendarContainer: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 6,
+    overflow: 'hidden',
+  },
+  weekHeader: {
+    flexDirection: 'row',
+    backgroundColor: colors.primary,
+  },
+  weekHeaderCell: {
+    flex: 1,
+    padding: 5,
+    textAlign: 'center',
+  },
+  weekHeaderText: {
+    fontSize: 7,
+    fontFamily: 'Helvetica-Bold',
+    color: colors.white,
+    textTransform: 'uppercase',
+  },
+  calendarGrid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  dayCell: {
+    width: '14.28%',
+    padding: 4,
+    borderRightWidth: 0.5,
+    borderBottomWidth: 0.5,
+    borderColor: colors.borderLight,
+    textAlign: 'center',
+    minHeight: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: colors.white,
+  },
+  dayCellEmpty: {
+    width: '14.28%',
+    padding: 4,
+    borderRightWidth: 0.5,
+    borderBottomWidth: 0.5,
+    borderColor: colors.borderLight,
+    backgroundColor: colors.backgroundAlt,
+    minHeight: 20,
+  },
+  dayCellWeekend: {
+    backgroundColor: colors.weekend,
+  },
+  dayCellWorked: {
+    backgroundColor: colors.worked,
+  },
+  dayText: {
+    fontSize: 8,
+    color: colors.text,
+  },
+  dayTextWeekend: {
+    color: colors.weekendText,
+  },
+  dayTextWorked: {
+    fontFamily: 'Helvetica-Bold',
+    color: colors.workedText,
+  },
+
+  // ==========================================================================
+  // LÉGENDE
+  // ==========================================================================
+  legend: {
+    flexDirection: 'row',
+    marginTop: 6,
+    gap: 20,
+    justifyContent: 'center',
+  },
+  legendItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+  },
+  legendBox: {
+    width: 10,
+    height: 10,
+    borderRadius: 2,
+    borderWidth: 0.5,
+    borderColor: colors.border,
+  },
+  legendBoxWorked: {
+    backgroundColor: colors.worked,
+    borderColor: colors.accentLight,
+  },
+  legendBoxWeekend: {
+    backgroundColor: colors.weekend,
+  },
+  legendText: {
+    fontSize: 7,
+    color: colors.textSecondary,
+  },
+
+  // ==========================================================================
+  // RÉSUMÉ
+  // ==========================================================================
+  summarySection: {
+    marginBottom: 10,
+    backgroundColor: colors.accent,
+    padding: 10,
+    borderRadius: 6,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 8,
+  },
+  summaryLabel: {
+    fontSize: 10,
+    color: colors.white,
+  },
+  summaryValue: {
+    fontSize: 16,
+    fontFamily: 'Helvetica-Bold',
+    color: colors.white,
+  },
+
+  // ==========================================================================
+  // COMMENTAIRE
+  // ==========================================================================
+  commentSection: {
+    marginBottom: 10,
+  },
+  commentTitle: {
+    fontSize: 10,
+    fontFamily: 'Helvetica-Bold',
+    marginBottom: 4,
+    color: colors.text,
+  },
+  commentBox: {
+    padding: 8,
+    backgroundColor: colors.background,
+    borderRadius: 4,
+    borderLeftWidth: 3,
+    borderLeftColor: colors.accent,
+  },
+  commentText: {
+    fontSize: 8,
+    color: colors.text,
+    lineHeight: 1.4,
+  },
+
+  // ==========================================================================
+  // SIGNATURES
+  // ==========================================================================
+  signaturesSection: {
+    marginTop: 'auto',
+    paddingTop: 8,
+  },
+  signaturesTitle: {
+    fontSize: 10,
+    fontFamily: 'Helvetica-Bold',
+    marginBottom: 8,
+    color: colors.text,
+    textAlign: 'center',
+  },
+  signaturesRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  signatureBlock: {
+    flex: 1,
+    padding: 10,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 6,
+    borderTopWidth: 3,
+    borderTopColor: colors.accent,
+    minHeight: 75,
+  },
+  signatureLabel: {
+    fontSize: 7,
+    color: colors.accent,
+    marginBottom: 3,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    fontFamily: 'Helvetica-Bold',
+  },
+  signatureCompany: {
+    fontSize: 9,
+    fontFamily: 'Helvetica-Bold',
+    color: colors.primary,
+    marginBottom: 6,
+  },
+  signatureImageContainer: {
+    height: 30,
+    marginBottom: 4,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  signatureImage: {
+    maxHeight: 30,
+    maxWidth: 90,
+    objectFit: 'contain',
+  },
+  signaturePlaceholder: {
+    height: 30,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.border,
+    borderBottomStyle: 'dashed',
+    marginBottom: 4,
+  },
+  signatureName: {
+    fontSize: 8,
+    fontFamily: 'Helvetica-Bold',
+    color: colors.text,
+  },
+  signatureTitle: {
+    fontSize: 7,
+    color: colors.textSecondary,
+    marginTop: 1,
+  },
+
+  // ==========================================================================
+  // FOOTER
+  // ==========================================================================
+  footer: {
+    position: 'absolute',
+    bottom: 15,
+    left: 30,
+    right: 30,
+    textAlign: 'center',
+    fontSize: 7,
+    color: colors.textLight,
+    borderTopWidth: 1,
+    borderTopColor: colors.border,
+    paddingTop: 6,
+  },
+});
+
+export { pdfStyles, colors };

--- a/src/lib/monthUtils.ts
+++ b/src/lib/monthUtils.ts
@@ -21,9 +21,14 @@ export const MONTHS = [
 ] as const;
 
 /**
- * Liste des jours de la semaine en français
+ * Liste des jours de la semaine en français (dimanche en premier)
  */
 export const WEEKDAYS = ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam'] as const;
+
+/**
+ * Liste des jours de la semaine en français (lundi en premier)
+ */
+export const WEEKDAYS_MONDAY_FIRST = ['Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam', 'Dim'] as const;
 
 /**
  * Obtient le nombre de jours dans un mois donné
@@ -113,6 +118,32 @@ export function getCalendarGrid(month: number, year: number): (DayInfo | null)[]
   // if (remainingDays < 7) {
   //   grid.push(...Array(remainingDays).fill(null));
   // }
+
+  return grid;
+}
+
+/**
+ * Génère une grille de calendrier commençant par lundi
+ * Retourne un tableau avec null pour les jours vides et DayInfo pour les jours réels
+ */
+export function getCalendarGridMondayFirst(month: number, year: number): (DayInfo | null)[] {
+  const firstDayOfWeek = getFirstDayOfMonth(month, year);
+  const monthDays = getMonthDays(month, year);
+
+  // Convertir dimanche=0 en dimanche=6 pour que lundi=0
+  const mondayBasedFirstDay = firstDayOfWeek === 0 ? 6 : firstDayOfWeek - 1;
+
+  // Ajouter des null au début pour aligner le premier jour
+  const grid: (DayInfo | null)[] = Array(mondayBasedFirstDay).fill(null);
+
+  // Ajouter les jours du mois
+  grid.push(...monthDays);
+
+  // Compléter la dernière semaine pour avoir un grid complet
+  const remainingDays = 7 - (grid.length % 7);
+  if (remainingDays < 7) {
+    grid.push(...Array(remainingDays).fill(null));
+  }
 
   return grid;
 }

--- a/src/pages/PreviewCRA.tsx
+++ b/src/pages/PreviewCRA.tsx
@@ -1,10 +1,13 @@
-import { useEffect } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { PDFViewer, pdf } from '@react-pdf/renderer';
 import { Button, StatusBadge, Spinner } from '@/components/ui';
 import { type CRAStatus } from '@/constants/cra.constants';
-import { formatMonthYear, formatWorkedDays } from '@/lib/monthUtils';
+import { formatMonthYear } from '@/lib/monthUtils';
 import { useCRA } from '@/hooks/useCRA';
 import { useCompanyStore } from '@/stores/company.store';
+import { CRAPDFDocument } from '@/components/pdf';
+import type { Company } from '@/types/company.types';
 
 export function PreviewCRA() {
   const navigate = useNavigate();
@@ -13,21 +16,66 @@ export function PreviewCRA() {
   const { cra: selectedCRA, isLoading, error } = useCRA(id);
   const companies = useCompanyStore((state) => state.companies);
   const fetchCompanies = useCompanyStore((state) => state.fetchCompanies);
+  const [isExporting, setIsExporting] = useState(false);
 
   // Charger les sociétés au montage
   useEffect(() => {
     fetchCompanies();
   }, [fetchCompanies]);
 
+  // Récupérer les objets Company complets
+  const getCompany = useCallback(
+    (companyId: string): Company | undefined => {
+      return companies.find((c) => c.id === companyId);
+    },
+    [companies]
+  );
+
+  const clientCompany = selectedCRA ? getCompany(selectedCRA.client_id) : undefined;
+  const providerCompany = selectedCRA ? getCompany(selectedCRA.provider_id) : undefined;
+
   // Fonction helper pour obtenir le nom d'une société
   const getCompanyName = (companyId: string) => {
-    const company = companies.find((c) => c.id === companyId);
+    const company = getCompany(companyId);
     return company?.designation || 'N/A';
   };
 
-  const handleExportPDF = () => {
-    // TODO: Implémenter l'export PDF
-    alert('Export PDF en cours de développement...');
+  const handleExportPDF = async () => {
+    if (!selectedCRA || !clientCompany || !providerCompany) return;
+
+    setIsExporting(true);
+    try {
+      const doc = (
+        <CRAPDFDocument
+          cra={selectedCRA}
+          clientCompany={clientCompany}
+          providerCompany={providerCompany}
+        />
+      );
+
+      const blob = await pdf(doc).toBlob();
+      const url = URL.createObjectURL(blob);
+
+      // Créer un nom de fichier descriptif
+      const monthYear = formatMonthYear(selectedCRA.month, selectedCRA.year).replace(' ', '-');
+      const filename = `CRA-${providerCompany.designation}-${clientCompany.designation}-${monthYear}.pdf`
+        .replace(/\s+/g, '_')
+        .replace(/[^a-zA-Z0-9_\-.]/g, '');
+
+      // Déclencher le téléchargement
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error('Erreur lors de l\'export PDF:', err);
+      alert('Une erreur est survenue lors de l\'export PDF');
+    } finally {
+      setIsExporting(false);
+    }
   };
 
   // Loader pendant le chargement
@@ -37,7 +85,9 @@ export function PreviewCRA() {
         <div className="flex items-center justify-center py-12">
           <div className="text-center">
             <Spinner />
-            <p className="mt-4 text-[rgb(var(--color-text-secondary))]">Chargement du CRA...</p>
+            <p className="mt-4 text-[rgb(var(--color-text-secondary))]">
+              Chargement du CRA...
+            </p>
           </div>
         </div>
       </div>
@@ -62,17 +112,11 @@ export function PreviewCRA() {
               />
             </svg>
             <div>
-              <h3 className="text-lg font-medium text-red-800">
-                CRA introuvable
-              </h3>
+              <h3 className="text-lg font-medium text-red-800">CRA introuvable</h3>
               <p className="text-sm text-red-700 mt-1">
                 {error || "Le CRA demandé n'existe pas ou n'a pas pu être chargé."}
               </p>
-              <Button
-                variant="outline"
-                className="mt-4"
-                onClick={() => navigate('/')}
-              >
+              <Button variant="outline" className="mt-4" onClick={() => navigate('/')}>
                 Retour au dashboard
               </Button>
             </div>
@@ -84,19 +128,37 @@ export function PreviewCRA() {
 
   if (!selectedCRA) return null;
 
-  // Calculer les statistiques
-  const workedDaysCount = selectedCRA.worked_days?.length || 0;
+  // Attendre que les companies soient chargées
+  if (!clientCompany || !providerCompany) {
+    return (
+      <div className="max-w-5xl mx-auto">
+        <div className="flex items-center justify-center py-12">
+          <div className="text-center">
+            <Spinner />
+            <p className="mt-4 text-[rgb(var(--color-text-secondary))]">
+              Chargement des informations...
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div className="max-w-5xl mx-auto">
+    <div className="max-w-7xl mx-auto">
       {/* Header */}
-      <div className="mb-8">
+      <div className="mb-6">
         <div className="flex items-center gap-2 text-sm text-[rgb(var(--color-text-secondary))] mb-2">
-          <button onClick={() => navigate('/')} className="hover:text-[rgb(var(--color-text))]">
+          <button
+            onClick={() => navigate('/')}
+            className="hover:text-[rgb(var(--color-text))]"
+          >
             Dashboard
           </button>
           <span>/</span>
-          <span className="text-[rgb(var(--color-text))]\">CRA #{id?.slice(0, 8)}</span>
+          <span className="text-[rgb(var(--color-text))]">
+            CRA #{id?.slice(0, 8)}
+          </span>
         </div>
         <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
           <div>
@@ -107,115 +169,58 @@ export function PreviewCRA() {
               <StatusBadge status={selectedCRA.status as CRAStatus} />
             </div>
             <p className="text-[rgb(var(--color-text-secondary))] mt-1">
-              {formatMonthYear(selectedCRA.month, selectedCRA.year)} - {getCompanyName(selectedCRA.provider_id)} → {getCompanyName(selectedCRA.client_id)}
+              {formatMonthYear(selectedCRA.month, selectedCRA.year)} -{' '}
+              {getCompanyName(selectedCRA.provider_id)} →{' '}
+              {getCompanyName(selectedCRA.client_id)}
             </p>
           </div>
           <div className="flex gap-3">
-            <Button
-              variant="outline"
-              onClick={() => navigate(`/cra/${id}/edit`)}
-            >
+            <Button variant="outline" onClick={() => navigate(`/cra/${id}/edit`)}>
               Éditer
             </Button>
-            <Button onClick={handleExportPDF}>
-              <svg
-                className="w-4 h-4 mr-2"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                />
-              </svg>
-              Exporter PDF
+            <Button onClick={handleExportPDF} disabled={isExporting}>
+              {isExporting ? (
+                <>
+                  <Spinner className="w-4 h-4 mr-2" />
+                  Export en cours...
+                </>
+              ) : (
+                <>
+                  <svg
+                    className="w-4 h-4 mr-2"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                    />
+                  </svg>
+                  Exporter PDF
+                </>
+              )}
             </Button>
           </div>
         </div>
       </div>
 
-      {/* CRA Preview */}
-      <div className="bg-[rgb(var(--color-surface))] rounded-lg border border-[rgb(var(--color-border))] shadow-sm">
-        {/* Header du CRA */}
-        <div className="border-b border-[rgb(var(--color-border))] p-6 bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-900/20 dark:to-indigo-900/20">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div>
-              <h3 className="text-sm font-medium text-[rgb(var(--color-text-secondary))] mb-1">
-                Période
-              </h3>
-              <p className="text-lg font-semibold text-[rgb(var(--color-text))]">
-                {formatMonthYear(selectedCRA.month, selectedCRA.year)}
-              </p>
-            </div>
-            <div>
-              <h3 className="text-sm font-medium text-[rgb(var(--color-text-secondary))] mb-1">
-                Prestataire
-              </h3>
-              <p className="text-lg font-semibold text-[rgb(var(--color-text))]">
-                {getCompanyName(selectedCRA.provider_id)}
-              </p>
-            </div>
-            <div>
-              <h3 className="text-sm font-medium text-[rgb(var(--color-text-secondary))] mb-1">Client</h3>
-              <p className="text-lg font-semibold text-[rgb(var(--color-text))]">
-                {getCompanyName(selectedCRA.client_id)}
-              </p>
-            </div>
-          </div>
-        </div>
-
-        {/* Jours travaillés */}
-        <div className="p-6 border-b border-[rgb(var(--color-border))]">
-          <h3 className="text-lg font-semibold text-[rgb(var(--color-text))] mb-4">
-            Jours travaillés
-          </h3>
-          {!selectedCRA.worked_days || selectedCRA.worked_days.length === 0 ? (
-            <div className="text-center py-8 bg-[rgb(var(--color-surface-hover))] rounded-lg">
-              <p className="text-[rgb(var(--color-text-secondary))]">Aucun jour travaillé renseigné</p>
-            </div>
-          ) : (
-            <div className="space-y-4">
-              <div className="bg-[rgb(var(--color-surface-hover))] rounded-lg p-4">
-                <p className="text-sm text-[rgb(var(--color-text-secondary))]">
-                  <span className="font-semibold text-[rgb(var(--color-text))]">
-                    {workedDaysCount} jour{workedDaysCount > 1 ? 's' : ''} travaillé{workedDaysCount > 1 ? 's' : ''}
-                  </span>
-                  {' : '}
-                  {formatWorkedDays(selectedCRA.worked_days)}
-                </p>
-              </div>
-            </div>
-          )}
-        </div>
-
-        {/* Commentaire */}
-        {selectedCRA.comment && (
-          <div className="p-6 border-b border-[rgb(var(--color-border))]">
-            <h3 className="text-lg font-semibold text-[rgb(var(--color-text))] mb-4">
-              Commentaire
-            </h3>
-            <div className="bg-[rgb(var(--color-surface-hover))] rounded-lg p-4">
-              <p className="text-[rgb(var(--color-text))] whitespace-pre-wrap">
-                {selectedCRA.comment}
-              </p>
-            </div>
-          </div>
-        )}
-
-        {/* Stats */}
-        <div className="p-6 bg-[rgb(var(--color-surface-hover))]">
-          <div className="flex justify-center">
-            <div className="text-center">
-              <p className="text-sm text-[rgb(var(--color-text-secondary))] mb-1">Jours travaillés</p>
-              <p className="text-2xl font-bold text-[rgb(var(--color-text))]">
-                {workedDaysCount}
-              </p>
-            </div>
-          </div>
-        </div>
+      {/* PDF Preview */}
+      <div className="bg-[rgb(var(--color-surface))] rounded-lg border border-[rgb(var(--color-border))] shadow-sm overflow-hidden">
+        <PDFViewer
+          width="100%"
+          height={800}
+          showToolbar={true}
+          className="border-0"
+        >
+          <CRAPDFDocument
+            cra={selectedCRA}
+            clientCompany={clientCompany}
+            providerCompany={providerCompany}
+          />
+        </PDFViewer>
       </div>
 
       {/* Actions */}

--- a/src/services/cra.service.ts
+++ b/src/services/cra.service.ts
@@ -119,30 +119,6 @@ export const craService = {
   },
 
   /**
-   * Génère un PDF pour un CRA
-   * @returns L'URL du PDF généré
-   */
-  async generatePDF(id: string): Promise<{ url: string }> {
-    return api.post<{ url: string }>(`/cras/${id}/pdf`, {});
-  },
-
-  /**
-   * Télécharge le PDF d'un CRA
-   * Cette fonction déclenche le téléchargement côté client
-   */
-  async downloadPDF(id: string): Promise<void> {
-    const { url } = await this.generatePDF(id);
-
-    // Créer un lien temporaire pour déclencher le téléchargement
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = `CRA-${id}.pdf`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-  },
-
-  /**
    * Recherche des CRAs par texte
    */
   async searchCRAs(query: string): Promise<CRA[]> {


### PR DESCRIPTION
## Summary

  - Ajout de la prévisualisation PDF intégrée dans la page de preview CRA
  - Export PDF avec téléchargement du fichier
  - Charte graphique DiscoData (marron chocolat / orange doré)

  ## Changes

  ### Nouveaux fichiers (`src/components/pdf/`)
  - `CRAPDFDocument.tsx` - Document PDF principal
  - `PDFHeader.tsx` - En-tête "Compte Rendu d'Activité"
  - `PDFInfoSection.tsx` - Détails complets des sociétés (adresse, SIREN, TVA...)
  - `PDFCalendarGrid.tsx` - Calendrier mensuel (semaine commençant lundi)
  - `PDFSummary.tsx` - Total des jours travaillés
  - `PDFComment.tsx` - Commentaire optionnel
  - `PDFSignatures.tsx` - Blocs signature prestataire/client
  - `pdfStyles.ts` - Styles avec palette DiscoData
  - `index.ts` - Barrel exports

  ### Fichiers modifiés
  - `PreviewCRA.tsx` - Intégration PDFViewer + bouton export
  - `monthUtils.ts` - Ajout `getCalendarGridMondayFirst()` et `WEEKDAYS_MONDAY_FIRST`
  - `cra.service.ts` - Suppression des stubs PDF serveur (obsolètes)

  ### Dépendance ajoutée
  - `@react-pdf/renderer` - Génération PDF côté client

  ## Test plan

  - [ ] Accéder à `/cra/:id/preview` avec un CRA existant
  - [ ] Vérifier l'affichage du PDF dans le viewer intégré
  - [ ] Cliquer sur "Exporter PDF" et vérifier le téléchargement
  - [ ] Vérifier que le PDF tient sur une seule page A4
  - [ ] Vérifier les informations des sociétés (SIREN, adresse, TVA...)
  - [ ] Vérifier que le calendrier commence bien le lundi