### PR TITLE
feat: add signature location and date fields for PDF export

### DIFF
--- a/backend/migrations/003_add_signature_location_date.sql
+++ b/backend/migrations/003_add_signature_location_date.sql
@@ -1,0 +1,33 @@
+-- Migration: Add signature location and date fields
+-- Date: 2025-12-07
+-- Description: Adds signature location (city) and use_current_date fields
+--              for "Fait à <VILLE>, le <DATE>" in PDF exports
+
+-- Companies: default signature location and date settings
+ALTER TABLE companies
+ADD COLUMN default_signature_location VARCHAR(255);
+
+ALTER TABLE companies
+ADD COLUMN default_use_current_date BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN companies.default_signature_location IS 'Ville par défaut pour la mention "Fait à..."';
+COMMENT ON COLUMN companies.default_use_current_date IS 'Utiliser la date du jour lors de la génération PDF';
+
+-- CRAs: per-CRA signature location and date overrides (client side)
+ALTER TABLE cras
+ADD COLUMN client_signature_location VARCHAR(255);
+
+ALTER TABLE cras
+ADD COLUMN client_use_current_date BOOLEAN;
+
+-- CRAs: per-CRA signature location and date overrides (provider side)
+ALTER TABLE cras
+ADD COLUMN provider_signature_location VARCHAR(255);
+
+ALTER TABLE cras
+ADD COLUMN provider_use_current_date BOOLEAN;
+
+COMMENT ON COLUMN cras.client_signature_location IS 'Lieu de signature client (surcharge)';
+COMMENT ON COLUMN cras.client_use_current_date IS 'Utiliser date courante pour signature client';
+COMMENT ON COLUMN cras.provider_signature_location IS 'Lieu de signature prestataire (surcharge)';
+COMMENT ON COLUMN cras.provider_use_current_date IS 'Utiliser date courante pour signature prestataire';

--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -30,7 +30,7 @@ pool.on('error', (err) => {
 // Fonction utilitaire pour exécuter des requêtes
 export const query = async <T extends pg.QueryResultRow = pg.QueryResultRow>(
   text: string,
-  params?: unknown[]
+  params?: unknown[],
 ): Promise<pg.QueryResult<T>> => {
   const start = Date.now();
   try {

--- a/backend/src/config/upload.config.ts
+++ b/backend/src/config/upload.config.ts
@@ -30,7 +30,7 @@ const storage = multer.diskStorage({
 const fileFilter = (
   _req: Request,
   file: Express.Multer.File,
-  cb: multer.FileFilterCallback
+  cb: multer.FileFilterCallback,
 ) => {
   // Vérifier le type MIME
   const allowedMimeTypes = ['image/png', 'image/jpeg', 'image/jpg'];
@@ -40,8 +40,8 @@ const fileFilter = (
   } else {
     cb(
       new Error(
-        'Format de fichier invalide. Seuls les fichiers PNG et JPEG sont acceptés.'
-      )
+        'Format de fichier invalide. Seuls les fichiers PNG et JPEG sont acceptés.',
+      ),
     );
   }
 };

--- a/backend/src/controllers/company.controller.ts
+++ b/backend/src/controllers/company.controller.ts
@@ -67,7 +67,7 @@ export class CompanyController {
    */
   private static validateCompanyData(
     data: Partial<CreateCompanyInput>,
-    isUpdate = false
+    isUpdate = false,
   ): { valid: boolean; error?: string } {
     // Validation des champs obligatoires (seulement pour la création)
     if (!isUpdate) {
@@ -105,12 +105,15 @@ export class CompanyController {
         return { valid: false, error: 'Le champ dispense est obligatoire' };
       }
       if (data.exemption === undefined) {
-        return { valid: false, error: "Le champ exemption est obligatoire" };
+        return { valid: false, error: 'Le champ exemption est obligatoire' };
       }
     }
 
     // Validation du code postal
-    if (data.postal_code && !VALIDATION_REGEX.POSTAL_CODE.test(data.postal_code)) {
+    if (
+      data.postal_code &&
+      !VALIDATION_REGEX.POSTAL_CODE.test(data.postal_code)
+    ) {
       return {
         valid: false,
         error: 'Le code postal doit contenir exactement 5 chiffres',
@@ -282,6 +285,9 @@ export class CompanyController {
         default_signatory_name: req.body.default_signatory_name || undefined,
         default_signatory_title: req.body.default_signatory_title || undefined,
         default_signature_image: req.body.default_signature_image || undefined,
+        default_signature_location:
+          req.body.default_signature_location || undefined,
+        default_use_current_date: req.body.default_use_current_date ?? false,
       };
 
       // Validation
@@ -324,15 +330,13 @@ export class CompanyController {
       // Construire les données de mise à jour à partir du body
       if (req.body.designation !== undefined)
         updateData.designation = req.body.designation;
-      if (req.body.address !== undefined)
-        updateData.address = req.body.address;
+      if (req.body.address !== undefined) updateData.address = req.body.address;
       if (req.body.complement !== undefined)
         updateData.complement = req.body.complement || null;
       if (req.body.city !== undefined) updateData.city = req.body.city;
       if (req.body.postal_code !== undefined)
         updateData.postal_code = req.body.postal_code;
-      if (req.body.country !== undefined)
-        updateData.country = req.body.country;
+      if (req.body.country !== undefined) updateData.country = req.body.country;
       if (req.body.email !== undefined) updateData.email = req.body.email;
       if (req.body.phone !== undefined)
         updateData.phone = req.body.phone || null;
@@ -347,18 +351,25 @@ export class CompanyController {
       if (req.body.registre_number !== undefined)
         updateData.registre_number = req.body.registre_number || null;
       if (req.body.liste !== undefined) updateData.liste = req.body.liste;
-      if (req.body.code !== undefined)
-        updateData.code = req.body.code || null;
+      if (req.body.code !== undefined) updateData.code = req.body.code || null;
       if (req.body.exemption !== undefined)
         updateData.exemption = req.body.exemption;
       if (req.body.tva_number !== undefined)
         updateData.tva_number = req.body.tva_number || null;
       if (req.body.default_signatory_name !== undefined)
-        updateData.default_signatory_name = req.body.default_signatory_name || null;
+        updateData.default_signatory_name =
+          req.body.default_signatory_name || null;
       if (req.body.default_signatory_title !== undefined)
-        updateData.default_signatory_title = req.body.default_signatory_title || null;
+        updateData.default_signatory_title =
+          req.body.default_signatory_title || null;
       if (req.body.default_signature_image !== undefined)
-        updateData.default_signature_image = req.body.default_signature_image || null;
+        updateData.default_signature_image =
+          req.body.default_signature_image || null;
+      if (req.body.default_signature_location !== undefined)
+        updateData.default_signature_location =
+          req.body.default_signature_location || null;
+      if (req.body.default_use_current_date !== undefined)
+        updateData.default_use_current_date = req.body.default_use_current_date;
 
       // Validation
       const validation = this.validateCompanyData(updateData, true);

--- a/backend/src/controllers/cra.controller.ts
+++ b/backend/src/controllers/cra.controller.ts
@@ -1,6 +1,10 @@
 import { Request, Response } from 'express';
 import { CRAModel } from '../models/cra.model.js';
-import { CreateCRAInput, UpdateCRAInput, CRAFilters } from '../types/cra.types.js';
+import {
+  CreateCRAInput,
+  UpdateCRAInput,
+  CRAFilters,
+} from '../types/cra.types.js';
 
 /**
  * Controller pour gérer les requêtes HTTP liées aux CRA mensuels
@@ -17,7 +21,9 @@ export class CRAController {
         client: req.query.client as string,
         provider: req.query.provider as string,
         year: req.query.year ? parseInt(req.query.year as string) : undefined,
-        month: req.query.month ? parseInt(req.query.month as string) : undefined,
+        month: req.query.month
+          ? parseInt(req.query.month as string)
+          : undefined,
         limit: req.query.limit ? parseInt(req.query.limit as string) : 50,
         offset: req.query.offset ? parseInt(req.query.offset as string) : 0,
       };
@@ -90,7 +96,8 @@ export class CRAController {
         res.status(400).json({
           success: false,
           error: 'Invalid input',
-          message: 'month, year, worked_days, client_id, and provider_id are required',
+          message:
+            'month, year, worked_days, client_id, and provider_id are required',
         });
         return;
       }
@@ -156,9 +163,18 @@ export class CRAController {
         client_signatory_name: req.body.client_signatory_name || undefined,
         client_signatory_title: req.body.client_signatory_title || undefined,
         client_signature_image: req.body.client_signature_image || undefined,
+        client_signature_location:
+          req.body.client_signature_location || undefined,
+        client_use_current_date: req.body.client_use_current_date ?? undefined,
         provider_signatory_name: req.body.provider_signatory_name || undefined,
-        provider_signatory_title: req.body.provider_signatory_title || undefined,
-        provider_signature_image: req.body.provider_signature_image || undefined,
+        provider_signatory_title:
+          req.body.provider_signatory_title || undefined,
+        provider_signature_image:
+          req.body.provider_signature_image || undefined,
+        provider_signature_location:
+          req.body.provider_signature_location || undefined,
+        provider_use_current_date:
+          req.body.provider_use_current_date ?? undefined,
       };
 
       const newCRA = await CRAModel.create(craData);
@@ -176,7 +192,8 @@ export class CRAController {
         res.status(409).json({
           success: false,
           error: 'Duplicate CRA',
-          message: 'Un CRA existe déjà pour ce mois, cette année et cette combinaison client/prestataire',
+          message:
+            'Un CRA existe déjà pour ce mois, cette année et cette combinaison client/prestataire',
         });
         return;
       }
@@ -200,7 +217,8 @@ export class CRAController {
 
       // Validation: si on met à jour client_id et provider_id, ils doivent être différents
       if (
-        (req.body.client_id !== undefined && req.body.provider_id !== undefined) &&
+        req.body.client_id !== undefined &&
+        req.body.provider_id !== undefined &&
         req.body.client_id === req.body.provider_id
       ) {
         res.status(400).json({
@@ -213,7 +231,11 @@ export class CRAController {
 
       // Validation du mois si présent
       if (req.body.month !== undefined) {
-        if (typeof req.body.month !== 'number' || req.body.month < 1 || req.body.month > 12) {
+        if (
+          typeof req.body.month !== 'number' ||
+          req.body.month < 1 ||
+          req.body.month > 12
+        ) {
           res.status(400).json({
             success: false,
             error: 'Invalid month',
@@ -226,7 +248,11 @@ export class CRAController {
 
       // Validation de l'année si présente
       if (req.body.year !== undefined) {
-        if (typeof req.body.year !== 'number' || req.body.year < 2000 || req.body.year > 2100) {
+        if (
+          typeof req.body.year !== 'number' ||
+          req.body.year < 2000 ||
+          req.body.year > 2100
+        ) {
           res.status(400).json({
             success: false,
             error: 'Invalid year',
@@ -252,22 +278,41 @@ export class CRAController {
 
       // Construire les données de mise à jour à partir du body
       if (req.body.comment !== undefined) updateData.comment = req.body.comment;
-      if (req.body.client_id !== undefined) updateData.client_id = req.body.client_id;
-      if (req.body.provider_id !== undefined) updateData.provider_id = req.body.provider_id;
+      if (req.body.client_id !== undefined)
+        updateData.client_id = req.body.client_id;
+      if (req.body.provider_id !== undefined)
+        updateData.provider_id = req.body.provider_id;
       if (req.body.status !== undefined) updateData.status = req.body.status;
       // Signatures - accepter null et undefined
       if (req.body.client_signatory_name !== undefined)
-        updateData.client_signatory_name = req.body.client_signatory_name || null;
+        updateData.client_signatory_name =
+          req.body.client_signatory_name || null;
       if (req.body.client_signatory_title !== undefined)
-        updateData.client_signatory_title = req.body.client_signatory_title || null;
+        updateData.client_signatory_title =
+          req.body.client_signatory_title || null;
       if (req.body.client_signature_image !== undefined)
-        updateData.client_signature_image = req.body.client_signature_image || null;
+        updateData.client_signature_image =
+          req.body.client_signature_image || null;
       if (req.body.provider_signatory_name !== undefined)
-        updateData.provider_signatory_name = req.body.provider_signatory_name || null;
+        updateData.provider_signatory_name =
+          req.body.provider_signatory_name || null;
       if (req.body.provider_signatory_title !== undefined)
-        updateData.provider_signatory_title = req.body.provider_signatory_title || null;
+        updateData.provider_signatory_title =
+          req.body.provider_signatory_title || null;
       if (req.body.provider_signature_image !== undefined)
-        updateData.provider_signature_image = req.body.provider_signature_image || null;
+        updateData.provider_signature_image =
+          req.body.provider_signature_image || null;
+      if (req.body.client_signature_location !== undefined)
+        updateData.client_signature_location =
+          req.body.client_signature_location || null;
+      if (req.body.client_use_current_date !== undefined)
+        updateData.client_use_current_date = req.body.client_use_current_date;
+      if (req.body.provider_signature_location !== undefined)
+        updateData.provider_signature_location =
+          req.body.provider_signature_location || null;
+      if (req.body.provider_use_current_date !== undefined)
+        updateData.provider_use_current_date =
+          req.body.provider_use_current_date;
 
       const updatedCRA = await CRAModel.update(id, updateData);
 
@@ -293,7 +338,8 @@ export class CRAController {
         res.status(409).json({
           success: false,
           error: 'Duplicate CRA',
-          message: 'Un CRA existe déjà pour ce mois, cette année et cette combinaison client/prestataire',
+          message:
+            'Un CRA existe déjà pour ce mois, cette année et cette combinaison client/prestataire',
         });
         return;
       }

--- a/backend/src/controllers/upload.controller.ts
+++ b/backend/src/controllers/upload.controller.ts
@@ -6,7 +6,10 @@ import fs from 'fs/promises';
  * Upload une signature et retourne le chemin du fichier
  * POST /api/upload/signature
  */
-export const uploadSignatureImage = async (req: Request, res: Response): Promise<void> => {
+export const uploadSignatureImage = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
   try {
     // Vérifier qu'un fichier a été uploadé
     if (!req.file) {
@@ -35,7 +38,7 @@ export const uploadSignatureImage = async (req: Request, res: Response): Promise
     res.status(500).json({
       success: false,
       error: 'Internal Server Error',
-      message: 'Erreur lors de l\'upload de la signature',
+      message: "Erreur lors de l'upload de la signature",
     });
   }
 };
@@ -44,7 +47,10 @@ export const uploadSignatureImage = async (req: Request, res: Response): Promise
  * Supprime une signature
  * DELETE /api/upload/signature/:filename
  */
-export const deleteSignatureImage = async (req: Request, res: Response): Promise<void> => {
+export const deleteSignatureImage = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
   try {
     const { filename } = req.params;
 
@@ -59,11 +65,7 @@ export const deleteSignatureImage = async (req: Request, res: Response): Promise
     }
 
     // Construire le chemin complet
-    const filePath = path.join(
-      __dirname,
-      '../../uploads/signatures',
-      filename
-    );
+    const filePath = path.join(__dirname, '../../uploads/signatures', filename);
 
     // Vérifier que le fichier existe
     try {

--- a/backend/src/models/company.model.ts
+++ b/backend/src/models/company.model.ts
@@ -46,6 +46,8 @@ export class CompanyModel {
         default_signatory_name,
         default_signatory_title,
         default_signature_image,
+        default_signature_location,
+        default_use_current_date,
         created_at,
         updated_at
       FROM companies
@@ -116,6 +118,8 @@ export class CompanyModel {
         default_signatory_name,
         default_signatory_title,
         default_signature_image,
+        default_signature_location,
+        default_use_current_date,
         created_at,
         updated_at
       FROM companies
@@ -151,9 +155,11 @@ export class CompanyModel {
         tva_number,
         default_signatory_name,
         default_signatory_title,
-        default_signature_image
+        default_signature_image,
+        default_signature_location,
+        default_use_current_date
       )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
       RETURNING
         id,
         designation,
@@ -176,6 +182,8 @@ export class CompanyModel {
         default_signatory_name,
         default_signatory_title,
         default_signature_image,
+        default_signature_location,
+        default_use_current_date,
         created_at,
         updated_at
     `;
@@ -201,6 +209,8 @@ export class CompanyModel {
       data.default_signatory_name || null,
       data.default_signatory_title || null,
       data.default_signature_image || null,
+      data.default_signature_location || null,
+      data.default_use_current_date ?? false,
     ];
 
     const result = await query<Company>(queryText, params);
@@ -212,7 +222,7 @@ export class CompanyModel {
    */
   static async update(
     id: string,
-    data: UpdateCompanyInput
+    data: UpdateCompanyInput,
   ): Promise<Company | null> {
     const client = await pool.connect();
 
@@ -344,6 +354,18 @@ export class CompanyModel {
         paramIndex++;
       }
 
+      if (data.default_signature_location !== undefined) {
+        updates.push(`default_signature_location = $${paramIndex}`);
+        params.push(data.default_signature_location || null);
+        paramIndex++;
+      }
+
+      if (data.default_use_current_date !== undefined) {
+        updates.push(`default_use_current_date = $${paramIndex}`);
+        params.push(data.default_use_current_date);
+        paramIndex++;
+      }
+
       // Toujours mettre à jour updated_at
       updates.push(`updated_at = CURRENT_TIMESTAMP`);
 
@@ -382,6 +404,8 @@ export class CompanyModel {
           default_signatory_name,
           default_signatory_title,
           default_signature_image,
+          default_signature_location,
+          default_use_current_date,
           created_at,
           updated_at
       `;
@@ -422,7 +446,7 @@ export class CompanyModel {
 
       if (count > 0) {
         throw new Error(
-          `Cette société est utilisée dans ${count} CRA(s) et ne peut pas être supprimée`
+          `Cette société est utilisée dans ${count} CRA(s) et ne peut pas être supprimée`,
         );
       }
 

--- a/backend/src/models/cra.model.ts
+++ b/backend/src/models/cra.model.ts
@@ -14,7 +14,15 @@ export class CRAModel {
    * Récupère tous les CRA avec filtres optionnels
    */
   static async findAll(filters: CRAFilters = {}): Promise<CRA[]> {
-    const { status, client, provider, year, month, limit = 50, offset = 0 } = filters;
+    const {
+      status,
+      client,
+      provider,
+      year,
+      month,
+      limit = 50,
+      offset = 0,
+    } = filters;
 
     let queryText = `
       SELECT
@@ -29,9 +37,13 @@ export class CRAModel {
         client_signatory_name,
         client_signatory_title,
         client_signature_image,
+        client_signature_location,
+        client_use_current_date,
         provider_signatory_name,
         provider_signatory_title,
         provider_signature_image,
+        provider_signature_location,
+        provider_use_current_date,
         created_at,
         updated_at
       FROM cras
@@ -98,9 +110,13 @@ export class CRAModel {
         client_signatory_name,
         client_signatory_title,
         client_signature_image,
+        client_signature_location,
+        client_use_current_date,
         provider_signatory_name,
         provider_signatory_title,
         provider_signature_image,
+        provider_signature_location,
+        provider_use_current_date,
         created_at,
         updated_at
       FROM cras
@@ -127,11 +143,15 @@ export class CRAModel {
         client_signatory_name,
         client_signatory_title,
         client_signature_image,
+        client_signature_location,
+        client_use_current_date,
         provider_signatory_name,
         provider_signatory_title,
-        provider_signature_image
+        provider_signature_image,
+        provider_signature_location,
+        provider_use_current_date
       )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
       RETURNING
         id,
         month,
@@ -144,9 +164,13 @@ export class CRAModel {
         client_signatory_name,
         client_signatory_title,
         client_signature_image,
+        client_signature_location,
+        client_use_current_date,
         provider_signatory_name,
         provider_signatory_title,
         provider_signature_image,
+        provider_signature_location,
+        provider_use_current_date,
         created_at,
         updated_at
     `;
@@ -162,9 +186,13 @@ export class CRAModel {
       data.client_signatory_name || null,
       data.client_signatory_title || null,
       data.client_signature_image || null,
+      data.client_signature_location || null,
+      data.client_use_current_date ?? null,
       data.provider_signatory_name || null,
       data.provider_signatory_title || null,
       data.provider_signature_image || null,
+      data.provider_signature_location || null,
+      data.provider_use_current_date ?? null,
     ]);
 
     return result.rows[0];
@@ -239,6 +267,18 @@ export class CRAModel {
       paramIndex++;
     }
 
+    if (data.client_signature_location !== undefined) {
+      updates.push(`client_signature_location = $${paramIndex}`);
+      params.push(data.client_signature_location || null);
+      paramIndex++;
+    }
+
+    if (data.client_use_current_date !== undefined) {
+      updates.push(`client_use_current_date = $${paramIndex}`);
+      params.push(data.client_use_current_date);
+      paramIndex++;
+    }
+
     if (data.provider_signatory_name !== undefined) {
       updates.push(`provider_signatory_name = $${paramIndex}`);
       params.push(data.provider_signatory_name || null);
@@ -254,6 +294,18 @@ export class CRAModel {
     if (data.provider_signature_image !== undefined) {
       updates.push(`provider_signature_image = $${paramIndex}`);
       params.push(data.provider_signature_image || null);
+      paramIndex++;
+    }
+
+    if (data.provider_signature_location !== undefined) {
+      updates.push(`provider_signature_location = $${paramIndex}`);
+      params.push(data.provider_signature_location || null);
+      paramIndex++;
+    }
+
+    if (data.provider_use_current_date !== undefined) {
+      updates.push(`provider_use_current_date = $${paramIndex}`);
+      params.push(data.provider_use_current_date);
       paramIndex++;
     }
 
@@ -284,9 +336,13 @@ export class CRAModel {
         client_signatory_name,
         client_signatory_title,
         client_signature_image,
+        client_signature_location,
+        client_use_current_date,
         provider_signatory_name,
         provider_signatory_title,
         provider_signature_image,
+        provider_signature_location,
+        provider_use_current_date,
         created_at,
         updated_at
     `;

--- a/backend/src/routes/upload.routes.ts
+++ b/backend/src/routes/upload.routes.ts
@@ -15,7 +15,7 @@ const router = Router();
 router.post(
   '/signature',
   uploadSignature.single('signature'),
-  uploadSignatureImage
+  uploadSignatureImage,
 );
 
 /**

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -24,7 +24,7 @@ app.use(
   cors({
     origin: process.env.CORS_ORIGIN || 'http://localhost:5173',
     credentials: true,
-  })
+  }),
 );
 
 // Middleware pour parser le JSON
@@ -88,7 +88,9 @@ async function startServer() {
 
     if (!dbConnected) {
       console.error('✗ Failed to connect to database');
-      console.error('Make sure PostgreSQL is running and the credentials are correct');
+      console.error(
+        'Make sure PostgreSQL is running and the credentials are correct',
+      );
       process.exit(1);
     }
 

--- a/backend/src/types/company.types.ts
+++ b/backend/src/types/company.types.ts
@@ -71,6 +71,8 @@ export interface Company {
   default_signatory_name?: string;
   default_signatory_title?: string;
   default_signature_image?: string;
+  default_signature_location?: string;
+  default_use_current_date: boolean;
 
   // Timestamps
   created_at: Date;
@@ -113,6 +115,8 @@ export interface CreateCompanyInput {
   default_signatory_name?: string;
   default_signatory_title?: string;
   default_signature_image?: string;
+  default_signature_location?: string;
+  default_use_current_date?: boolean;
 }
 
 export interface UpdateCompanyInput {
@@ -137,6 +141,8 @@ export interface UpdateCompanyInput {
   default_signatory_name?: string;
   default_signatory_title?: string;
   default_signature_image?: string;
+  default_signature_location?: string;
+  default_use_current_date?: boolean;
 }
 
 export interface CompanyFilters {

--- a/backend/src/types/cra.types.ts
+++ b/backend/src/types/cra.types.ts
@@ -11,21 +11,25 @@ export interface Activity {
 
 export interface CRA {
   id: string;
-  month: number;              // 1-12 (Janvier = 1, Décembre = 12)
-  year: number;               // Année (ex: 2025)
-  worked_days: number[];      // Liste des jours travaillés du mois
-  comment?: string;           // Commentaire global optionnel
-  client_id: string;          // UUID de la société cliente
-  provider_id: string;        // UUID de la société prestataire
+  month: number; // 1-12 (Janvier = 1, Décembre = 12)
+  year: number; // Année (ex: 2025)
+  worked_days: number[]; // Liste des jours travaillés du mois
+  comment?: string; // Commentaire global optionnel
+  client_id: string; // UUID de la société cliente
+  provider_id: string; // UUID de la société prestataire
   status: 'draft' | 'submitted' | 'approved' | 'rejected';
 
   // Signatures (overrides de la signature par défaut de la société)
   client_signatory_name?: string;
   client_signatory_title?: string;
   client_signature_image?: string;
+  client_signature_location?: string;
+  client_use_current_date?: boolean;
   provider_signatory_name?: string;
   provider_signatory_title?: string;
   provider_signature_image?: string;
+  provider_signature_location?: string;
+  provider_use_current_date?: boolean;
 
   created_at: Date;
   updated_at: Date;
@@ -44,9 +48,13 @@ export interface CreateCRAInput {
   client_signatory_name?: string;
   client_signatory_title?: string;
   client_signature_image?: string;
+  client_signature_location?: string;
+  client_use_current_date?: boolean;
   provider_signatory_name?: string;
   provider_signatory_title?: string;
   provider_signature_image?: string;
+  provider_signature_location?: string;
+  provider_use_current_date?: boolean;
 }
 
 export interface UpdateCRAInput {
@@ -62,17 +70,21 @@ export interface UpdateCRAInput {
   client_signatory_name?: string;
   client_signatory_title?: string;
   client_signature_image?: string;
+  client_signature_location?: string;
+  client_use_current_date?: boolean;
   provider_signatory_name?: string;
   provider_signatory_title?: string;
   provider_signature_image?: string;
+  provider_signature_location?: string;
+  provider_use_current_date?: boolean;
 }
 
 export interface CRAFilters {
   status?: string;
-  client?: string;            // UUID de la société cliente
-  provider?: string;          // UUID de la société prestataire
-  year?: number;             // Filtrer par année
-  month?: number;            // Filtrer par mois
+  client?: string; // UUID de la société cliente
+  provider?: string; // UUID de la société prestataire
+  year?: number; // Filtrer par année
+  month?: number; // Filtrer par mois
   limit?: number;
   offset?: number;
 }
@@ -82,7 +94,7 @@ export interface CRAFilters {
  * Utilisé pour afficher et gérer les signatures dans les composants UI
  */
 export interface SignatureData {
-  signatoryName: string;      // Nom du signataire
-  signatoryTitle: string;     // Titre/fonction du signataire
-  signatureImage: string;     // Chemin ou URL de l'image de signature
+  signatoryName: string; // Nom du signataire
+  signatoryTitle: string; // Titre/fonction du signataire
+  signatureImage: string; // Chemin ou URL de l'image de signature
 }

--- a/src/components/pdf/CRAPDFDocument.tsx
+++ b/src/components/pdf/CRAPDFDocument.tsx
@@ -70,6 +70,10 @@ export function CRAPDFDocument({
     name: cra.client_signatory_name || clientCompany.default_signatory_name,
     title: cra.client_signatory_title || clientCompany.default_signatory_title,
     image: cra.client_signature_image || clientCompany.default_signature_image,
+    location:
+      cra.client_signature_location || clientCompany.default_signature_location,
+    useCurrentDate:
+      cra.client_use_current_date ?? clientCompany.default_use_current_date,
   };
 
   const providerSignature = {
@@ -78,6 +82,11 @@ export function CRAPDFDocument({
       cra.provider_signatory_title || providerCompany.default_signatory_title,
     image:
       cra.provider_signature_image || providerCompany.default_signature_image,
+    location:
+      cra.provider_signature_location ||
+      providerCompany.default_signature_location,
+    useCurrentDate:
+      cra.provider_use_current_date ?? providerCompany.default_use_current_date,
   };
 
   return (

--- a/src/components/pdf/PDFSignatures.tsx
+++ b/src/components/pdf/PDFSignatures.tsx
@@ -24,6 +24,10 @@ interface SignatureInfo {
   title?: string;
   /** Chemin ou URL de l'image de signature */
   image?: string;
+  /** Lieu de signature (ville) */
+  location?: string;
+  /** Utiliser la date courante */
+  useCurrentDate?: boolean;
 }
 
 interface PDFSignaturesProps {
@@ -45,6 +49,33 @@ function getSignatureImageUrl(path?: string): string | null {
   if (path.startsWith('http') || path.startsWith('data:')) return path;
   const baseUrl = env.apiUrl?.replace('/api', '') || 'http://localhost:3001';
   return `${baseUrl}${path}`;
+}
+
+/**
+ * Vérifie si les champs lieu/date sont vides (nécessitant un remplissage manuel)
+ */
+function isManualEntry(location?: string, useCurrentDate?: boolean): boolean {
+  return !location && !useCurrentDate;
+}
+
+/**
+ * Formate la ligne "Fait à <VILLE>,"
+ */
+function formatFaitALocation(location?: string): string {
+  const locationPart = location
+    ? location.toUpperCase()
+    : '________________________';
+  return `Fait à ${locationPart},`;
+}
+
+/**
+ * Formate la ligne "le <DATE>"
+ */
+function formatFaitADate(useCurrentDate?: boolean): string {
+  const datePart = useCurrentDate
+    ? new Date().toLocaleDateString('fr-FR')
+    : '____/____/_______';
+  return `le ${datePart}`;
 }
 
 /**
@@ -81,6 +112,24 @@ export function PDFSignatures({
               {providerSignature.title && (
                 <Text style={pdfStyles.signatureTitle}>
                   {providerSignature.title}
+                </Text>
+              )}
+              {isManualEntry(
+                providerSignature.location,
+                providerSignature.useCurrentDate,
+              ) ? (
+                <>
+                  <Text style={pdfStyles.faitAEmpty}>
+                    {formatFaitALocation(providerSignature.location)}
+                  </Text>
+                  <Text style={pdfStyles.faitAEmptyDate}>
+                    {formatFaitADate(providerSignature.useCurrentDate)}
+                  </Text>
+                </>
+              ) : (
+                <Text style={pdfStyles.faitA}>
+                  {formatFaitALocation(providerSignature.location)}{' '}
+                  {formatFaitADate(providerSignature.useCurrentDate)}
                 </Text>
               )}
               <Text style={pdfStyles.luEtApprouvePlaceholder}>
@@ -121,6 +170,24 @@ export function PDFSignatures({
               {clientSignature.title && (
                 <Text style={pdfStyles.signatureTitle}>
                   {clientSignature.title}
+                </Text>
+              )}
+              {isManualEntry(
+                clientSignature.location,
+                clientSignature.useCurrentDate,
+              ) ? (
+                <>
+                  <Text style={pdfStyles.faitAEmpty}>
+                    {formatFaitALocation(clientSignature.location)}
+                  </Text>
+                  <Text style={pdfStyles.faitAEmptyDate}>
+                    {formatFaitADate(clientSignature.useCurrentDate)}
+                  </Text>
+                </>
+              ) : (
+                <Text style={pdfStyles.faitA}>
+                  {formatFaitALocation(clientSignature.location)}{' '}
+                  {formatFaitADate(clientSignature.useCurrentDate)}
                 </Text>
               )}
               <Text style={pdfStyles.luEtApprouvePlaceholder}>

--- a/src/components/pdf/pdfStyles.ts
+++ b/src/components/pdf/pdfStyles.ts
@@ -383,6 +383,26 @@ const pdfStyles = StyleSheet.create({
     fontStyle: 'italic',
     marginTop: 4,
   },
+  // "Fait à..." line above "lu et approuvé"
+  faitA: {
+    fontSize: 8,
+    color: colors.text,
+    marginTop: 6,
+    marginBottom: 2,
+  },
+  // "Fait à..." with empty fields (more space for manual writing)
+  faitAEmpty: {
+    fontSize: 8,
+    color: colors.text,
+    marginTop: 6,
+    marginBottom: 0,
+  },
+  faitAEmptyDate: {
+    fontSize: 8,
+    color: colors.text,
+    marginTop: 8,
+    marginBottom: 2,
+  },
   // Espace réservé pour notes manuscrites
   signatureNotesSpace: {
     height: 12,

--- a/src/components/ui/SignatureInput.tsx
+++ b/src/components/ui/SignatureInput.tsx
@@ -72,6 +72,8 @@ export function SignatureInput({
       signatoryName: '',
       signatoryTitle: '',
       signatureImage: '',
+      signatureLocation: '',
+      useCurrentDate: false,
     });
     setUploadError(null);
   };
@@ -82,6 +84,8 @@ export function SignatureInput({
         signatoryName: defaultSignature.signatoryName || '',
         signatoryTitle: defaultSignature.signatoryTitle || '',
         signatureImage: defaultSignature.signatureImage || '',
+        signatureLocation: defaultSignature.signatureLocation || '',
+        useCurrentDate: defaultSignature.useCurrentDate ?? false,
       });
     }
   };
@@ -95,11 +99,17 @@ export function SignatureInput({
   };
 
   const hasValue =
-    value.signatoryName || value.signatoryTitle || value.signatureImage;
+    value.signatoryName ||
+    value.signatoryTitle ||
+    value.signatureImage ||
+    value.signatureLocation ||
+    value.useCurrentDate;
   const hasDefault =
     defaultSignature?.signatoryName ||
     defaultSignature?.signatoryTitle ||
-    defaultSignature?.signatureImage;
+    defaultSignature?.signatureImage ||
+    defaultSignature?.signatureLocation ||
+    defaultSignature?.useCurrentDate;
 
   return (
     <div className="flex flex-col gap-4 p-4 border border-[rgb(var(--color-border))] rounded-lg bg-[rgb(var(--color-surface))]">
@@ -155,6 +165,36 @@ export function SignatureInput({
         disabled={disabled}
         fullWidth
       />
+
+      {/* Lieu de signature */}
+      <Input
+        label="Lieu de signature"
+        type="text"
+        value={value.signatureLocation || ''}
+        onChange={(e) =>
+          onChange({ ...value, signatureLocation: e.target.value })
+        }
+        placeholder="ex: MONTPELLIER"
+        helperText="Ville pour la mention « Fait à ... »"
+        disabled={disabled}
+        fullWidth
+      />
+
+      {/* Utiliser la date du jour */}
+      <label className="flex items-center gap-3 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={value.useCurrentDate || false}
+          onChange={(e) =>
+            onChange({ ...value, useCurrentDate: e.target.checked })
+          }
+          disabled={disabled}
+          className="w-4 h-4 rounded border-[rgb(var(--color-border))] text-[rgb(var(--color-primary))] focus:ring-[rgb(var(--color-primary))]"
+        />
+        <span className="text-sm text-[rgb(var(--color-text))]">
+          Utiliser la date du jour à la génération du PDF
+        </span>
+      </label>
 
       {/* Upload d'image */}
       <div className="flex flex-col gap-2">

--- a/src/pages/CreateCRA.tsx
+++ b/src/pages/CreateCRA.tsx
@@ -98,6 +98,8 @@ export function CreateCRA() {
           signatoryName: clientCompany.default_signatory_name || '',
           signatoryTitle: clientCompany.default_signatory_title || '',
           signatureImage: clientCompany.default_signature_image || '',
+          signatureLocation: clientCompany.default_signature_location || '',
+          useCurrentDate: clientCompany.default_use_current_date ?? false,
         }
       : undefined;
 
@@ -107,6 +109,8 @@ export function CreateCRA() {
           signatoryName: providerCompany.default_signatory_name || '',
           signatoryTitle: providerCompany.default_signatory_title || '',
           signatureImage: providerCompany.default_signature_image || '',
+          signatureLocation: providerCompany.default_signature_location || '',
+          useCurrentDate: providerCompany.default_use_current_date ?? false,
         }
       : undefined;
 
@@ -137,9 +141,13 @@ export function CreateCRA() {
         client_signatory_name: data.client_signatory_name,
         client_signatory_title: data.client_signatory_title,
         client_signature_image: data.client_signature_image,
+        client_signature_location: data.client_signature_location,
+        client_use_current_date: data.client_use_current_date,
         provider_signatory_name: data.provider_signatory_name,
         provider_signatory_title: data.provider_signatory_title,
         provider_signature_image: data.provider_signature_image,
+        provider_signature_location: data.provider_signature_location,
+        provider_use_current_date: data.provider_use_current_date,
       });
 
       addNotification('CRA créé avec succès', 'success');
@@ -385,20 +393,39 @@ export function CreateCRA() {
                       name="client_signature_image"
                       control={control}
                       render={({ field: imageField }) => (
-                        <SignatureInput
-                          label={`Signature ${clientCompany?.designation || 'Client'}`}
-                          value={{
-                            signatoryName: nameField.value || '',
-                            signatoryTitle: titleField.value || '',
-                            signatureImage: imageField.value || '',
-                          }}
-                          onChange={(sig) => {
-                            nameField.onChange(sig.signatoryName);
-                            titleField.onChange(sig.signatoryTitle);
-                            imageField.onChange(sig.signatureImage);
-                          }}
-                          defaultSignature={clientDefaultSignature}
-                          disabled={!selectedClientId}
+                        <Controller
+                          name="client_signature_location"
+                          control={control}
+                          render={({ field: locationField }) => (
+                            <Controller
+                              name="client_use_current_date"
+                              control={control}
+                              render={({ field: dateField }) => (
+                                <SignatureInput
+                                  label={`Signature ${clientCompany?.designation || 'Client'}`}
+                                  value={{
+                                    signatoryName: nameField.value || '',
+                                    signatoryTitle: titleField.value || '',
+                                    signatureImage: imageField.value || '',
+                                    signatureLocation:
+                                      locationField.value || '',
+                                    useCurrentDate: dateField.value ?? false,
+                                  }}
+                                  onChange={(sig) => {
+                                    nameField.onChange(sig.signatoryName);
+                                    titleField.onChange(sig.signatoryTitle);
+                                    imageField.onChange(sig.signatureImage);
+                                    locationField.onChange(
+                                      sig.signatureLocation,
+                                    );
+                                    dateField.onChange(sig.useCurrentDate);
+                                  }}
+                                  defaultSignature={clientDefaultSignature}
+                                  disabled={!selectedClientId}
+                                />
+                              )}
+                            />
+                          )}
                         />
                       )}
                     />
@@ -420,20 +447,39 @@ export function CreateCRA() {
                       name="provider_signature_image"
                       control={control}
                       render={({ field: imageField }) => (
-                        <SignatureInput
-                          label={`Signature ${providerCompany?.designation || 'Prestataire'}`}
-                          value={{
-                            signatoryName: nameField.value || '',
-                            signatoryTitle: titleField.value || '',
-                            signatureImage: imageField.value || '',
-                          }}
-                          onChange={(sig) => {
-                            nameField.onChange(sig.signatoryName);
-                            titleField.onChange(sig.signatoryTitle);
-                            imageField.onChange(sig.signatureImage);
-                          }}
-                          defaultSignature={providerDefaultSignature}
-                          disabled={!selectedProviderId}
+                        <Controller
+                          name="provider_signature_location"
+                          control={control}
+                          render={({ field: locationField }) => (
+                            <Controller
+                              name="provider_use_current_date"
+                              control={control}
+                              render={({ field: dateField }) => (
+                                <SignatureInput
+                                  label={`Signature ${providerCompany?.designation || 'Prestataire'}`}
+                                  value={{
+                                    signatoryName: nameField.value || '',
+                                    signatoryTitle: titleField.value || '',
+                                    signatureImage: imageField.value || '',
+                                    signatureLocation:
+                                      locationField.value || '',
+                                    useCurrentDate: dateField.value ?? false,
+                                  }}
+                                  onChange={(sig) => {
+                                    nameField.onChange(sig.signatoryName);
+                                    titleField.onChange(sig.signatoryTitle);
+                                    imageField.onChange(sig.signatureImage);
+                                    locationField.onChange(
+                                      sig.signatureLocation,
+                                    );
+                                    dateField.onChange(sig.useCurrentDate);
+                                  }}
+                                  defaultSignature={providerDefaultSignature}
+                                  disabled={!selectedProviderId}
+                                />
+                              )}
+                            />
+                          )}
                         />
                       )}
                     />

--- a/src/pages/CreateCompany.tsx
+++ b/src/pages/CreateCompany.tsx
@@ -64,6 +64,9 @@ export function CreateCompany() {
         default_signatory_name: data.default_signatory_name || undefined,
         default_signatory_title: data.default_signatory_title || undefined,
         default_signature_image: data.default_signature_image || undefined,
+        default_signature_location:
+          data.default_signature_location || undefined,
+        default_use_current_date: data.default_use_current_date ?? false,
       };
 
       await createCompany(cleanedData);
@@ -335,18 +338,34 @@ export function CreateCompany() {
                     name="default_signature_image"
                     control={control}
                     render={({ field: imageField }) => (
-                      <SignatureInput
-                        label="Signature par défaut"
-                        value={{
-                          signatoryName: nameField.value || '',
-                          signatoryTitle: titleField.value || '',
-                          signatureImage: imageField.value || '',
-                        }}
-                        onChange={(sig: Partial<SignatureData>) => {
-                          nameField.onChange(sig.signatoryName);
-                          titleField.onChange(sig.signatoryTitle);
-                          imageField.onChange(sig.signatureImage);
-                        }}
+                      <Controller
+                        name="default_signature_location"
+                        control={control}
+                        render={({ field: locationField }) => (
+                          <Controller
+                            name="default_use_current_date"
+                            control={control}
+                            render={({ field: dateField }) => (
+                              <SignatureInput
+                                label="Signature par défaut"
+                                value={{
+                                  signatoryName: nameField.value || '',
+                                  signatoryTitle: titleField.value || '',
+                                  signatureImage: imageField.value || '',
+                                  signatureLocation: locationField.value || '',
+                                  useCurrentDate: dateField.value ?? false,
+                                }}
+                                onChange={(sig: Partial<SignatureData>) => {
+                                  nameField.onChange(sig.signatoryName);
+                                  titleField.onChange(sig.signatoryTitle);
+                                  imageField.onChange(sig.signatureImage);
+                                  locationField.onChange(sig.signatureLocation);
+                                  dateField.onChange(sig.useCurrentDate);
+                                }}
+                              />
+                            )}
+                          />
+                        )}
                       />
                     )}
                   />

--- a/src/pages/EditCRA.tsx
+++ b/src/pages/EditCRA.tsx
@@ -74,9 +74,16 @@ export function EditCRA() {
           client_signatory_name: selectedCRA.client_signatory_name || '',
           client_signatory_title: selectedCRA.client_signatory_title || '',
           client_signature_image: selectedCRA.client_signature_image || '',
+          client_signature_location:
+            selectedCRA.client_signature_location || '',
+          client_use_current_date: selectedCRA.client_use_current_date ?? false,
           provider_signatory_name: selectedCRA.provider_signatory_name || '',
           provider_signatory_title: selectedCRA.provider_signatory_title || '',
           provider_signature_image: selectedCRA.provider_signature_image || '',
+          provider_signature_location:
+            selectedCRA.provider_signature_location || '',
+          provider_use_current_date:
+            selectedCRA.provider_use_current_date ?? false,
         }
       : {},
   );
@@ -95,9 +102,15 @@ export function EditCRA() {
         client_signatory_name: selectedCRA.client_signatory_name || '',
         client_signatory_title: selectedCRA.client_signatory_title || '',
         client_signature_image: selectedCRA.client_signature_image || '',
+        client_signature_location: selectedCRA.client_signature_location || '',
+        client_use_current_date: selectedCRA.client_use_current_date ?? false,
         provider_signatory_name: selectedCRA.provider_signatory_name || '',
         provider_signatory_title: selectedCRA.provider_signatory_title || '',
         provider_signature_image: selectedCRA.provider_signature_image || '',
+        provider_signature_location:
+          selectedCRA.provider_signature_location || '',
+        provider_use_current_date:
+          selectedCRA.provider_use_current_date ?? false,
       });
       setSelectedMonth(selectedCRA.month);
       setSelectedYear(selectedCRA.year);
@@ -157,6 +170,8 @@ export function EditCRA() {
           signatoryName: clientCompany.default_signatory_name || '',
           signatoryTitle: clientCompany.default_signatory_title || '',
           signatureImage: clientCompany.default_signature_image || '',
+          signatureLocation: clientCompany.default_signature_location || '',
+          useCurrentDate: clientCompany.default_use_current_date ?? false,
         }
       : undefined;
 
@@ -166,6 +181,8 @@ export function EditCRA() {
           signatoryName: providerCompany.default_signatory_name || '',
           signatoryTitle: providerCompany.default_signatory_title || '',
           signatureImage: providerCompany.default_signature_image || '',
+          signatureLocation: providerCompany.default_signature_location || '',
+          useCurrentDate: providerCompany.default_use_current_date ?? false,
         }
       : undefined;
 
@@ -198,9 +215,13 @@ export function EditCRA() {
         client_signatory_name: data.client_signatory_name || null,
         client_signatory_title: data.client_signatory_title || null,
         client_signature_image: data.client_signature_image || null,
+        client_signature_location: data.client_signature_location || null,
+        client_use_current_date: data.client_use_current_date ?? null,
         provider_signatory_name: data.provider_signatory_name || null,
         provider_signatory_title: data.provider_signatory_title || null,
         provider_signature_image: data.provider_signature_image || null,
+        provider_signature_location: data.provider_signature_location || null,
+        provider_use_current_date: data.provider_use_current_date ?? null,
       });
 
       addNotification('CRA mis à jour avec succès', 'success');
@@ -537,20 +558,39 @@ export function EditCRA() {
                       name="client_signature_image"
                       control={control}
                       render={({ field: imageField }) => (
-                        <SignatureInput
-                          label={`Signature ${clientCompany?.designation || 'Client'}`}
-                          value={{
-                            signatoryName: nameField.value || '',
-                            signatoryTitle: titleField.value || '',
-                            signatureImage: imageField.value || '',
-                          }}
-                          onChange={(sig) => {
-                            nameField.onChange(sig.signatoryName);
-                            titleField.onChange(sig.signatoryTitle);
-                            imageField.onChange(sig.signatureImage);
-                          }}
-                          defaultSignature={clientDefaultSignature}
-                          disabled={!selectedClientId}
+                        <Controller
+                          name="client_signature_location"
+                          control={control}
+                          render={({ field: locationField }) => (
+                            <Controller
+                              name="client_use_current_date"
+                              control={control}
+                              render={({ field: dateField }) => (
+                                <SignatureInput
+                                  label={`Signature ${clientCompany?.designation || 'Client'}`}
+                                  value={{
+                                    signatoryName: nameField.value || '',
+                                    signatoryTitle: titleField.value || '',
+                                    signatureImage: imageField.value || '',
+                                    signatureLocation:
+                                      locationField.value || '',
+                                    useCurrentDate: dateField.value ?? false,
+                                  }}
+                                  onChange={(sig) => {
+                                    nameField.onChange(sig.signatoryName);
+                                    titleField.onChange(sig.signatoryTitle);
+                                    imageField.onChange(sig.signatureImage);
+                                    locationField.onChange(
+                                      sig.signatureLocation,
+                                    );
+                                    dateField.onChange(sig.useCurrentDate);
+                                  }}
+                                  defaultSignature={clientDefaultSignature}
+                                  disabled={!selectedClientId}
+                                />
+                              )}
+                            />
+                          )}
                         />
                       )}
                     />
@@ -572,20 +612,39 @@ export function EditCRA() {
                       name="provider_signature_image"
                       control={control}
                       render={({ field: imageField }) => (
-                        <SignatureInput
-                          label={`Signature ${providerCompany?.designation || 'Prestataire'}`}
-                          value={{
-                            signatoryName: nameField.value || '',
-                            signatoryTitle: titleField.value || '',
-                            signatureImage: imageField.value || '',
-                          }}
-                          onChange={(sig) => {
-                            nameField.onChange(sig.signatoryName);
-                            titleField.onChange(sig.signatoryTitle);
-                            imageField.onChange(sig.signatureImage);
-                          }}
-                          defaultSignature={providerDefaultSignature}
-                          disabled={!selectedProviderId}
+                        <Controller
+                          name="provider_signature_location"
+                          control={control}
+                          render={({ field: locationField }) => (
+                            <Controller
+                              name="provider_use_current_date"
+                              control={control}
+                              render={({ field: dateField }) => (
+                                <SignatureInput
+                                  label={`Signature ${providerCompany?.designation || 'Prestataire'}`}
+                                  value={{
+                                    signatoryName: nameField.value || '',
+                                    signatoryTitle: titleField.value || '',
+                                    signatureImage: imageField.value || '',
+                                    signatureLocation:
+                                      locationField.value || '',
+                                    useCurrentDate: dateField.value ?? false,
+                                  }}
+                                  onChange={(sig) => {
+                                    nameField.onChange(sig.signatoryName);
+                                    titleField.onChange(sig.signatoryTitle);
+                                    imageField.onChange(sig.signatureImage);
+                                    locationField.onChange(
+                                      sig.signatureLocation,
+                                    );
+                                    dateField.onChange(sig.useCurrentDate);
+                                  }}
+                                  defaultSignature={providerDefaultSignature}
+                                  disabled={!selectedProviderId}
+                                />
+                              )}
+                            />
+                          )}
                         />
                       )}
                     />

--- a/src/pages/EditCompany.tsx
+++ b/src/pages/EditCompany.tsx
@@ -88,6 +88,10 @@ export function EditCompany() {
         default_signatory_name: selectedCompany.default_signatory_name || '',
         default_signatory_title: selectedCompany.default_signatory_title || '',
         default_signature_image: selectedCompany.default_signature_image || '',
+        default_signature_location:
+          selectedCompany.default_signature_location || '',
+        default_use_current_date:
+          selectedCompany.default_use_current_date ?? false,
       });
     }
   }, [selectedCompany, reset]);
@@ -113,6 +117,8 @@ export function EditCompany() {
         default_signatory_name: data.default_signatory_name || null,
         default_signatory_title: data.default_signatory_title || null,
         default_signature_image: data.default_signature_image || null,
+        default_signature_location: data.default_signature_location || null,
+        default_use_current_date: data.default_use_current_date ?? false,
       };
 
       await updateCompany(id, cleanedData);
@@ -402,18 +408,34 @@ export function EditCompany() {
                     name="default_signature_image"
                     control={control}
                     render={({ field: imageField }) => (
-                      <SignatureInput
-                        label="Signature par défaut"
-                        value={{
-                          signatoryName: nameField.value || '',
-                          signatoryTitle: titleField.value || '',
-                          signatureImage: imageField.value || '',
-                        }}
-                        onChange={(sig: Partial<SignatureData>) => {
-                          nameField.onChange(sig.signatoryName);
-                          titleField.onChange(sig.signatoryTitle);
-                          imageField.onChange(sig.signatureImage);
-                        }}
+                      <Controller
+                        name="default_signature_location"
+                        control={control}
+                        render={({ field: locationField }) => (
+                          <Controller
+                            name="default_use_current_date"
+                            control={control}
+                            render={({ field: dateField }) => (
+                              <SignatureInput
+                                label="Signature par défaut"
+                                value={{
+                                  signatoryName: nameField.value || '',
+                                  signatoryTitle: titleField.value || '',
+                                  signatureImage: imageField.value || '',
+                                  signatureLocation: locationField.value || '',
+                                  useCurrentDate: dateField.value ?? false,
+                                }}
+                                onChange={(sig: Partial<SignatureData>) => {
+                                  nameField.onChange(sig.signatoryName);
+                                  titleField.onChange(sig.signatoryTitle);
+                                  imageField.onChange(sig.signatureImage);
+                                  locationField.onChange(sig.signatureLocation);
+                                  dateField.onChange(sig.useCurrentDate);
+                                }}
+                              />
+                            )}
+                          />
+                        )}
                       />
                     )}
                   />

--- a/src/pages/PreviewCRA.tsx
+++ b/src/pages/PreviewCRA.tsx
@@ -62,10 +62,11 @@ export function PreviewCRA() {
 
       // Créer un nom de fichier descriptif : CRA-Prestataire-Client-Mois-Année.pdf
       const monthYear = formatMonthYear(selectedCRA.month, selectedCRA.year);
-      const filename = `CRA-${providerCompany.designation}-${clientCompany.designation}-${monthYear}.pdf`
-        .replace(/\s+/g, '-')
-        .normalize('NFD')
-        .replace(/[\u0300-\u036f]/g, ''); // Supprime les accents
+      const filename =
+        `CRA-${providerCompany.designation}-${clientCompany.designation}-${monthYear}.pdf`
+          .replace(/\s+/g, '-')
+          .normalize('NFD')
+          .replace(/[\u0300-\u036f]/g, ''); // Supprime les accents
 
       // Déclencher le téléchargement
       const link = document.createElement('a');

--- a/src/schemas/company.schema.ts
+++ b/src/schemas/company.schema.ts
@@ -153,6 +153,8 @@ export const companyFormSchema = z
     default_signatory_name: z.string().max(255).optional(),
     default_signatory_title: z.string().max(255).optional(),
     default_signature_image: z.string().max(500).optional(),
+    default_signature_location: z.string().max(255).optional(),
+    default_use_current_date: z.boolean().optional(),
   })
   .refine(
     (data) => {

--- a/src/schemas/cra.schema.ts
+++ b/src/schemas/cra.schema.ts
@@ -88,9 +88,13 @@ export const craFormSchema = z
     client_signatory_name: z.string().max(255).optional(),
     client_signatory_title: z.string().max(255).optional(),
     client_signature_image: z.string().max(500).optional(),
+    client_signature_location: z.string().max(255).optional(),
+    client_use_current_date: z.boolean().optional(),
     provider_signatory_name: z.string().max(255).optional(),
     provider_signatory_title: z.string().max(255).optional(),
     provider_signature_image: z.string().max(500).optional(),
+    provider_signature_location: z.string().max(255).optional(),
+    provider_use_current_date: z.boolean().optional(),
   })
   .refine((data) => data.client_id !== data.provider_id, {
     message: 'Le client et le prestataire doivent être différents',

--- a/src/types/company.types.ts
+++ b/src/types/company.types.ts
@@ -71,6 +71,8 @@ export interface Company {
   default_signatory_name?: string;
   default_signatory_title?: string;
   default_signature_image?: string;
+  default_signature_location?: string;
+  default_use_current_date?: boolean;
 
   // Timestamps
   created_at: string;
@@ -113,6 +115,8 @@ export interface CreateCompanyInput {
   default_signatory_name?: string;
   default_signatory_title?: string;
   default_signature_image?: string;
+  default_signature_location?: string;
+  default_use_current_date?: boolean;
 }
 
 // Options pour les selects

--- a/src/types/cra.types.ts
+++ b/src/types/cra.types.ts
@@ -21,9 +21,13 @@ export interface CRA {
   client_signatory_name?: string;
   client_signatory_title?: string;
   client_signature_image?: string;
+  client_signature_location?: string;
+  client_use_current_date?: boolean;
   provider_signatory_name?: string;
   provider_signatory_title?: string;
   provider_signature_image?: string;
+  provider_signature_location?: string;
+  provider_use_current_date?: boolean;
 
   created_at: string; // Format ISO 8601
   updated_at: string; // Format ISO 8601
@@ -45,9 +49,13 @@ export type CreateCRAInput = {
   client_signatory_name?: string;
   client_signatory_title?: string;
   client_signature_image?: string;
+  client_signature_location?: string;
+  client_use_current_date?: boolean;
   provider_signatory_name?: string;
   provider_signatory_title?: string;
   provider_signature_image?: string;
+  provider_signature_location?: string;
+  provider_use_current_date?: boolean;
 };
 
 /**
@@ -66,9 +74,13 @@ export type UpdateCRAInput = {
   client_signatory_name?: string;
   client_signatory_title?: string;
   client_signature_image?: string;
+  client_signature_location?: string;
+  client_use_current_date?: boolean;
   provider_signatory_name?: string;
   provider_signatory_title?: string;
   provider_signature_image?: string;
+  provider_signature_location?: string;
+  provider_use_current_date?: boolean;
 };
 
 /**
@@ -100,4 +112,6 @@ export interface SignatureData {
   signatoryName: string; // Nom du signataire
   signatoryTitle: string; // Titre/fonction du signataire
   signatureImage: string; // Chemin ou URL de l'image de signature
+  signatureLocation?: string; // Lieu de signature (ville)
+  useCurrentDate?: boolean; // Utiliser la date du jour
 }


### PR DESCRIPTION
Ajout des champs lieu et date de signature pour l'export PDF des CRAs.

  - Ajout des champs default_signature_location et default_use_current_date au niveau société (signature par défaut)
  - Ajout des surcharges par CRA pour les signatures client et prestataire (client_signature_location, client_use_current_date, provider_signature_location, provider_use_current_date)
  - Affichage "Fait à , le " dans les blocs de signature PDF
  - Espaces réservés (underscores) pour saisie manuscrite quand les champs sont vides
  - Espacement vertical adapté pour faciliter l'écriture manuelle

  Test plan

  - Créer une société avec lieu de signature et date automatique activée
  - Vérifier que les champs apparaissent pré-remplis dans le formulaire CRA
  - Créer un CRA et surcharger les valeurs de signature
  - Exporter le PDF et vérifier l'affichage "Fait à VILLE, le DD/MM/YYYY"
  - Créer un CRA sans lieu/date et vérifier les espaces vides dans le PDF
  - Vérifier l'espacement vertical suffisant pour écriture manuscrite