### PR TITLE
feat: improve PDF preview and calendar with week numbers

### DIFF
--- a/src/components/pdf/CRAPDFDocument.tsx
+++ b/src/components/pdf/CRAPDFDocument.tsx
@@ -123,8 +123,7 @@ export function CRAPDFDocument({
         />
 
         <Text style={pdfStyles.footer}>
-          Document généré automatiquement -{' '}
-          {new Date().toLocaleDateString('fr-FR')}
+          Document généré automatiquement par crafter – © {new Date().getFullYear()} DiscoData. Tous droits réservés.
         </Text>
       </Page>
     </Document>

--- a/src/components/pdf/PDFCalendarGrid.tsx
+++ b/src/components/pdf/PDFCalendarGrid.tsx
@@ -2,7 +2,7 @@
  * Grille calendrier du PDF CRA
  *
  * Affiche un calendrier mensuel avec les jours travaillés mis en évidence.
- * La semaine commence le lundi.
+ * La semaine commence le lundi. Chaque ligne affiche le numéro de semaine ISO.
  */
 
 import { View, Text } from '@react-pdf/renderer';
@@ -10,7 +10,9 @@ import type { Style } from '@react-pdf/types';
 import { pdfStyles } from './pdfStyles';
 import {
   getCalendarGridMondayFirst,
+  getWeekNumber,
   WEEKDAYS_MONDAY_FIRST,
+  type DayInfo,
 } from '@/lib/monthUtils';
 
 interface PDFCalendarGridProps {
@@ -23,6 +25,28 @@ interface PDFCalendarGridProps {
 }
 
 /**
+ * Découpe la grille en lignes de 7 jours
+ */
+function chunkIntoWeeks(grid: (DayInfo | null)[]): (DayInfo | null)[][] {
+  const weeks: (DayInfo | null)[][] = [];
+  for (let i = 0; i < grid.length; i += 7) {
+    weeks.push(grid.slice(i, i + 7));
+  }
+  return weeks;
+}
+
+/**
+ * Trouve le premier jour réel dans une semaine pour calculer le numéro de semaine
+ */
+function getWeekNumberForRow(week: (DayInfo | null)[]): number | null {
+  const firstDay = week.find((day) => day !== null);
+  if (firstDay) {
+    return getWeekNumber(firstDay.date);
+  }
+  return null;
+}
+
+/**
  * Grille calendrier avec jours travaillés et weekends différenciés
  */
 export function PDFCalendarGrid({
@@ -31,6 +55,7 @@ export function PDFCalendarGrid({
   workedDays,
 }: PDFCalendarGridProps) {
   const grid = getCalendarGridMondayFirst(month, year);
+  const weeks = chunkIntoWeeks(grid);
   const workedDaysSet = new Set(workedDays);
 
   /**
@@ -56,8 +81,11 @@ export function PDFCalendarGrid({
   return (
     <View style={pdfStyles.calendarSection}>
       <View style={pdfStyles.calendarContainer}>
-        {/* En-tête des jours (Lun-Dim) */}
+        {/* En-tête : Sem + Lun-Dim */}
         <View style={pdfStyles.weekHeader}>
+          <View style={pdfStyles.weekNumberHeaderCell}>
+            <Text style={pdfStyles.weekNumberHeaderText}>Sem</Text>
+          </View>
           {WEEKDAYS_MONDAY_FIRST.map((day) => (
             <View key={day} style={pdfStyles.weekHeaderCell}>
               <Text style={pdfStyles.weekHeaderText}>{day}</Text>
@@ -65,23 +93,45 @@ export function PDFCalendarGrid({
           ))}
         </View>
 
-        {/* Grille des jours */}
+        {/* Lignes par semaine */}
         <View style={pdfStyles.calendarGrid}>
-          {grid.map((dayInfo, index) => {
-            if (!dayInfo) {
-              return (
-                <View key={`empty-${index}`} style={pdfStyles.dayCellEmpty} />
-              );
-            }
-
-            const isWorked = workedDaysSet.has(dayInfo.day);
-            const isWeekend = dayInfo.isWeekend;
+          {weeks.map((week, weekIndex) => {
+            const weekNumber = getWeekNumberForRow(week);
 
             return (
-              <View key={dayInfo.day} style={getCellStyle(isWeekend, isWorked)}>
-                <Text style={getTextStyle(isWeekend, isWorked)}>
-                  {dayInfo.day}
-                </Text>
+              <View key={`week-${weekIndex}`} style={pdfStyles.calendarRow}>
+                {/* Numéro de semaine */}
+                <View style={pdfStyles.weekNumberCell}>
+                  <Text style={pdfStyles.weekNumberText}>
+                    {weekNumber !== null ? `n°${weekNumber}` : ''}
+                  </Text>
+                </View>
+
+                {/* 7 jours de la semaine */}
+                {week.map((dayInfo, dayIndex) => {
+                  if (!dayInfo) {
+                    return (
+                      <View
+                        key={`empty-${weekIndex}-${dayIndex}`}
+                        style={pdfStyles.dayCellEmpty}
+                      />
+                    );
+                  }
+
+                  const isWorked = workedDaysSet.has(dayInfo.day);
+                  const isWeekend = dayInfo.isWeekend;
+
+                  return (
+                    <View
+                      key={dayInfo.day}
+                      style={getCellStyle(isWeekend, isWorked)}
+                    >
+                      <Text style={getTextStyle(isWeekend, isWorked)}>
+                        {dayInfo.day}
+                      </Text>
+                    </View>
+                  );
+                })}
               </View>
             );
           })}

--- a/src/components/pdf/pdfStyles.ts
+++ b/src/components/pdf/pdfStyles.ts
@@ -151,7 +151,7 @@ const pdfStyles = StyleSheet.create({
     backgroundColor: colors.primary,
   },
   weekHeaderCell: {
-    flex: 1,
+    width: '13.14%',
     padding: 5,
     textAlign: 'center',
   },
@@ -161,12 +161,48 @@ const pdfStyles = StyleSheet.create({
     color: colors.white,
     textTransform: 'uppercase',
   },
+  // Colonne numéro de semaine (header)
+  weekNumberHeaderCell: {
+    width: '8%',
+    padding: 5,
+    textAlign: 'center',
+    backgroundColor: colors.primaryLight,
+  },
+  weekNumberHeaderText: {
+    fontSize: 6,
+    fontFamily: 'Helvetica-Bold',
+    color: colors.white,
+    textTransform: 'uppercase',
+  },
   calendarGrid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
   },
+  // Ligne de semaine (numéro + 7 jours)
+  calendarRow: {
+    flexDirection: 'row',
+    width: '100%',
+  },
+  // Cellule numéro de semaine dans le corps du calendrier
+  // Fond blanc pour ne pas confondre avec les week-ends (même gris)
+  weekNumberCell: {
+    width: '8%',
+    padding: 4,
+    backgroundColor: colors.white,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRightWidth: 0.5,
+    borderBottomWidth: 0.5,
+    borderColor: colors.border,
+    minHeight: 20,
+  },
+  weekNumberText: {
+    fontSize: 6,
+    color: colors.textLight,
+    fontFamily: 'Helvetica-Bold',
+  },
   dayCell: {
-    width: '14.28%',
+    width: '13.14%',
     padding: 4,
     borderRightWidth: 0.5,
     borderBottomWidth: 0.5,
@@ -178,7 +214,7 @@ const pdfStyles = StyleSheet.create({
     backgroundColor: colors.white,
   },
   dayCellEmpty: {
-    width: '14.28%',
+    width: '13.14%',
     padding: 4,
     borderRightWidth: 0.5,
     borderBottomWidth: 0.5,

--- a/src/lib/monthUtils.ts
+++ b/src/lib/monthUtils.ts
@@ -237,3 +237,22 @@ export function getAvailableYears(
 
   return years;
 }
+
+/**
+ * Calcule le numéro de semaine ISO 8601
+ * La semaine 1 est celle contenant le premier jeudi de l'année
+ * Les semaines commencent le lundi
+ */
+export function getWeekNumber(date: Date): number {
+  const d = new Date(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()),
+  );
+  // Définir le jour de la semaine (1=lundi, 7=dimanche)
+  const dayNum = d.getUTCDay() || 7;
+  // Ajuster au jeudi de la même semaine
+  d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+  // Obtenir le premier jour de l'année
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  // Calculer le numéro de semaine
+  return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+}

--- a/src/pages/PreviewCRA.tsx
+++ b/src/pages/PreviewCRA.tsx
@@ -227,7 +227,7 @@ export function PreviewCRA() {
       <div className="bg-[rgb(var(--color-surface))] rounded-lg border border-[rgb(var(--color-border))] shadow-sm overflow-hidden">
         <PDFViewer
           width="100%"
-          height={800}
+          height={1200}
           showToolbar={true}
           className="border-0"
         >


### PR DESCRIPTION
## Summary

  - **Suppression du scroll interne** : Augmentation de la hauteur du PDFViewer (800 → 1200px) pour afficher le PDF A4 entièrement et utiliser uniquement le scroll du navigateur
  - **Ajout des numéros de semaine ISO** : Nouvelle colonne à gauche du calendrier affichant les semaines (n°48, n°49, etc.) pour mieux situer les jours dans le temps
  - **Amélioration de la cohérence visuelle** : Fond blanc pour les numéros de semaine afin d'éviter la confusion avec les week-ends (même gris)
  - **Mise à jour du pied de page** : "Document généré automatiquement par crafter – © 2025 DiscoData. Tous droits réservés." avec année dynamique

  ## Fichiers modifiés

  | Fichier | Modification |
  |---------|--------------|
  | `src/pages/PreviewCRA.tsx` | Hauteur PDFViewer 800 → 1200px |
  | `src/lib/monthUtils.ts` | Ajout fonction `getWeekNumber()` (ISO 8601) |
  | `src/components/pdf/pdfStyles.ts` | Styles pour colonne numéros de semaine |
  | `src/components/pdf/PDFCalendarGrid.tsx` | Restructuration avec numéros de semaine |
  | `src/components/pdf/CRAPDFDocument.tsx` | Nouveau texte footer avec copyright |

  ## Test plan

  - [ ] Vérifier que le PDF s'affiche sans scroll interne dans le viewer
  - [ ] Vérifier que les numéros de semaine s'affichent correctement (n°1 à n°53)
  - [ ] Vérifier que les numéros de semaine ont un fond blanc distinct des week-ends
  - [ ] Vérifier le nouveau footer avec l'année courante
  - [ ] Exporter un PDF et vérifier le rendu final