### PR TITLE
feat: add cryptocurrency donation section with BTC/ETH support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ VITE_AI_API_KEY=
 
 # Application Name
 VITE_APP_NAME=Crafter
+
+# Donation addresses (optional)
+VITE_DONATION_BTC=
+VITE_DONATION_ETH=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,10 @@ VITE_AI_API_KEY=
 
 # Application Name
 VITE_APP_NAME=Crafter
+
+# Donation addresses (optionnel, pour afficher les boutons de dons)
+VITE_DONATION_BTC=
+VITE_DONATION_ETH=
 ```
 
 **Important** :
@@ -128,10 +132,13 @@ src/
    - Navigation avec `<Link>` et `useNavigate()`
    - Paramètres dynamiques avec `useParams()`
    - Routes principales :
-     - `/` → Dashboard
-     - `/cra/new` → CreateCRA
-     - `/cra/:id/edit` → EditCRA
-     - `/cra/:id/preview` → PreviewCRA
+     - `/` → Landing (page publique)
+     - `/login`, `/register` → Authentification
+     - `/dashboard` → Dashboard (utilisateurs connectés)
+     - `/dashboard/cra/new` → CreateCRA
+     - `/dashboard/cra/:id/edit` → EditCRA
+     - `/dashboard/cra/:id/preview` → PreviewCRA
+     - `/dashboard/companies` → Liste des sociétés
 
 Exemple de configuration du router :
 ```tsx
@@ -139,13 +146,20 @@ import { createBrowserRouter } from 'react-router-dom';
 import { AppLayout } from '@/components/layout/AppLayout';
 
 export const router = createBrowserRouter([
+  // Routes publiques
+  { path: '/', element: <Landing /> },
+  { path: '/login', element: <Login /> },
+  { path: '/register', element: <Register /> },
+
+  // Routes protégées (utilisateurs connectés)
   {
-    path: '/',
-    element: <AppLayout />,
+    path: '/dashboard',
+    element: <ProtectedRoute><AppLayout /></ProtectedRoute>,
     children: [
       { index: true, element: <Dashboard /> },
       { path: 'cra/new', element: <CreateCRA /> },
       { path: 'cra/:id/edit', element: <EditCRA /> },
+      { path: 'companies', element: <Companies /> },
     ],
   },
 ]);

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -78,6 +78,8 @@ Le projet utilise les variables d'environnement Vite (préfixe `VITE_`):
 - `VITE_API_URL` - URL de l'API backend
 - `VITE_AI_API_KEY` - Clé API pour services IA (optionnel)
 - `VITE_APP_NAME` - Nom de l'application
+- `VITE_DONATION_BTC` - Adresse Bitcoin pour les dons (optionnel)
+- `VITE_DONATION_ETH` - Adresse Ethereum ERC20 pour les dons (optionnel)
 
 Fichiers de configuration :
 - `.env.example` - Template (versionné)

--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ Format de réponse API :
 VITE_API_URL=http://localhost:3001/api
 VITE_AI_API_KEY=
 VITE_APP_NAME=Crafter
+VITE_DONATION_BTC=       # Adresse Bitcoin (optionnel)
+VITE_DONATION_ETH=       # Adresse Ethereum ERC20 (optionnel)
 ```
 
 #### Backend (`backend/.env`)

--- a/src/components/features/DonationModal.tsx
+++ b/src/components/features/DonationModal.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react';
+import { Modal } from '@/components/ui/Modal';
+
+interface DonationModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const BTC_ADDRESS = import.meta.env.VITE_DONATION_BTC;
+const ETH_ADDRESS = import.meta.env.VITE_DONATION_ETH;
+
+function truncateAddress(address: string): string {
+  if (address.length <= 16) return address;
+  return `${address.slice(0, 8)}...${address.slice(-8)}`;
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback for older browsers
+      const textArea = document.createElement('textarea');
+      textArea.value = text;
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textArea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="px-3 py-1 text-sm font-medium rounded-md bg-[rgb(var(--color-surface-hover))] text-[rgb(var(--color-text))] hover:bg-[rgb(var(--color-border))] transition-colors"
+    >
+      {copied ? 'Copié !' : 'Copier'}
+    </button>
+  );
+}
+
+function AddressRow({
+  icon,
+  label,
+  address,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  address: string;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2 text-[rgb(var(--color-text))]">
+        {icon}
+        <span className="font-medium">{label}</span>
+      </div>
+      <div className="flex items-center gap-2 p-3 rounded-lg bg-[rgb(var(--color-bg))] border border-[rgb(var(--color-border))]">
+        <code className="flex-1 text-sm text-[rgb(var(--color-text-secondary))] font-mono">
+          {truncateAddress(address)}
+        </code>
+        <CopyButton text={address} />
+      </div>
+    </div>
+  );
+}
+
+// Bitcoin icon
+function BitcoinIcon() {
+  return (
+    <svg className="w-5 h-5 text-[#F7931A]" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M23.638 14.904c-1.602 6.43-8.113 10.34-14.542 8.736C2.67 22.05-1.244 15.525.362 9.105 1.962 2.67 8.475-1.243 14.9.358c6.43 1.605 10.342 8.115 8.738 14.546zm-6.35-4.613c.24-1.59-.974-2.45-2.64-3.03l.54-2.153-1.315-.33-.526 2.107c-.345-.087-.7-.168-1.053-.25l.53-2.12-1.317-.33-.54 2.153c-.286-.065-.568-.13-.843-.197l.001-.007-1.815-.453-.35 1.407s.974.223.955.238c.534.133.63.485.614.764l-.614 2.465c.037.01.085.024.136.045l-.138-.035-.86 3.45c-.065.16-.23.4-.605.307.013.02-.955-.238-.955-.238l-.652 1.514 1.714.427c.318.08.63.163.94.24l-.545 2.19 1.313.328.54-2.157c.36.1.707.19 1.046.273l-.537 2.152 1.316.327.546-2.183c2.245.427 3.93.254 4.64-1.778.57-1.635-.027-2.578-1.21-3.193.86-.198 1.508-.766 1.68-1.938zm-3.01 4.22c-.404 1.64-3.157.752-4.05.53l.72-2.9c.896.224 3.757.67 3.33 2.37zm.41-4.24c-.37 1.49-2.662.733-3.405.548l.654-2.63c.744.186 3.137.534 2.75 2.082z" />
+    </svg>
+  );
+}
+
+// Ethereum icon
+function EthereumIcon() {
+  return (
+    <svg className="w-5 h-5 text-[#627EEA]" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M11.944 17.97L4.58 13.62 11.943 24l7.37-10.38-7.372 4.35h.003zM12.056 0L4.69 12.223l7.365 4.354 7.365-4.35L12.056 0z" />
+    </svg>
+  );
+}
+
+export function DonationModal({ isOpen, onClose }: DonationModalProps) {
+  const hasAnyAddress = BTC_ADDRESS || ETH_ADDRESS;
+
+  if (!hasAnyAddress) return null;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Soutenir le projet">
+      <div className="space-y-4">
+        {BTC_ADDRESS && (
+          <AddressRow
+            icon={<BitcoinIcon />}
+            label="Bitcoin"
+            address={BTC_ADDRESS}
+          />
+        )}
+
+        {ETH_ADDRESS && (
+          <AddressRow
+            icon={<EthereumIcon />}
+            label="Ethereum (ERC20)"
+            address={ETH_ADDRESS}
+          />
+        )}
+
+        <p className="text-center text-sm text-[rgb(var(--color-text-muted))] pt-2">
+          Merci pour votre soutien !
+        </p>
+      </div>
+    </Modal>
+  );
+}
+
+// Export icons for use in footer
+export { BitcoinIcon, EthereumIcon };

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -4,6 +4,14 @@ import { cn } from '@/lib/utils';
 import { useAppStore, useSystemThemeListener } from '@/stores/app.store';
 import { useAuthStore } from '@/stores/auth.store';
 import { ThemeToggle } from '@/components/ui/ThemeToggle';
+import {
+  DonationModal,
+  BitcoinIcon,
+  EthereumIcon,
+} from '@/components/features/DonationModal';
+
+const BTC_ADDRESS = import.meta.env.VITE_DONATION_BTC;
+const ETH_ADDRESS = import.meta.env.VITE_DONATION_ETH;
 
 export function AppLayout() {
   const location = useLocation();
@@ -18,6 +26,10 @@ export function AppLayout() {
   // Menu utilisateur
   const [showUserMenu, setShowUserMenu] = useState(false);
   const userMenuRef = useRef<HTMLDivElement>(null);
+
+  // Modal de dons
+  const [isDonationModalOpen, setIsDonationModalOpen] = useState(false);
+  const hasDonationAddresses = BTC_ADDRESS || ETH_ADDRESS;
 
   // Fermer le menu en cliquant à l'extérieur
   useEffect(() => {
@@ -221,7 +233,26 @@ export function AppLayout() {
             <div className="text-sm text-[rgb(var(--color-text-muted))]">
               © 2025 DiscoData. Tous droits réservés.
             </div>
-            <div className="flex space-x-6 text-sm text-[rgb(var(--color-text-muted))]">
+            <div className="flex items-center space-x-6 text-sm text-[rgb(var(--color-text-muted))]">
+              {hasDonationAddresses && (
+                <button
+                  onClick={() => setIsDonationModalOpen(true)}
+                  className="flex items-center gap-1.5 hover:text-[rgb(var(--color-text))] transition-colors group cursor-pointer"
+                  aria-label="Soutenir le projet"
+                >
+                  {BTC_ADDRESS && (
+                    <span className="transition-transform duration-500 group-hover:rotate-[360deg]">
+                      <BitcoinIcon />
+                    </span>
+                  )}
+                  {ETH_ADDRESS && (
+                    <span className="transition-transform duration-500 group-hover:rotate-[360deg]">
+                      <EthereumIcon />
+                    </span>
+                  )}
+                  <span>Soutenir</span>
+                </button>
+              )}
               <a
                 href="#"
                 className="hover:text-[rgb(var(--color-text))] transition-colors"
@@ -246,6 +277,11 @@ export function AppLayout() {
           </div>
         </div>
       </footer>
+
+      <DonationModal
+        isOpen={isDonationModalOpen}
+        onClose={() => setIsDonationModalOpen(false)}
+      />
     </div>
   );
 }

--- a/src/components/ui/EXAMPLES.md
+++ b/src/components/ui/EXAMPLES.md
@@ -1,6 +1,6 @@
-# Exemples d'utilisation des composants de formulaire
+# Exemples d'utilisation des composants UI
 
-Ce document présente des exemples d'utilisation des composants de formulaire UI.
+Ce document présente des exemples d'utilisation des composants UI.
 
 ## Import des composants
 
@@ -408,3 +408,71 @@ Tous les composants acceptent une prop `className` pour personnalisation :
   ...
 </FormSection>
 ```
+
+## Modal
+
+Composant modal réutilisable avec overlay, fermeture au clic extérieur et support clavier (Escape).
+
+### Import
+
+```tsx
+import { Modal } from '@/components/ui/Modal';
+```
+
+### Utilisation basique
+
+```tsx
+import { useState } from 'react';
+import { Modal } from '@/components/ui/Modal';
+
+function MyComponent() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <button onClick={() => setIsOpen(true)}>Ouvrir la modal</button>
+
+      <Modal
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        title="Titre de la modal"
+      >
+        <p>Contenu de la modal</p>
+      </Modal>
+    </>
+  );
+}
+```
+
+### Sans titre (modal simple)
+
+```tsx
+<Modal isOpen={isOpen} onClose={handleClose}>
+  <div className="text-center">
+    <p>Êtes-vous sûr de vouloir continuer ?</p>
+    <div className="mt-4 flex justify-center gap-2">
+      <button onClick={handleClose}>Annuler</button>
+      <button onClick={handleConfirm}>Confirmer</button>
+    </div>
+  </div>
+</Modal>
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `isOpen` | `boolean` | - | Contrôle l'affichage de la modal |
+| `onClose` | `() => void` | - | Callback appelé à la fermeture |
+| `title` | `string` | - | Titre affiché dans le header (optionnel) |
+| `className` | `string` | - | Classes CSS additionnelles |
+| `children` | `ReactNode` | - | Contenu de la modal |
+
+### Fonctionnalités
+
+- ✅ Fermeture au clic sur l'overlay
+- ✅ Fermeture avec la touche Escape
+- ✅ Bloque le scroll du body quand ouverte
+- ✅ Animation d'apparition (fade + zoom)
+- ✅ Support du thème dark/light
+- ✅ Accessibilité (role="dialog", aria-modal, aria-labelledby)

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,0 +1,101 @@
+import { HTMLAttributes, forwardRef, useEffect, useCallback } from 'react';
+import { cn } from '@/lib/utils';
+
+interface ModalProps extends HTMLAttributes<HTMLDivElement> {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+}
+
+const Modal = forwardRef<HTMLDivElement, ModalProps>(
+  ({ className, isOpen, onClose, title, children, ...props }, ref) => {
+    const handleEscape = useCallback(
+      (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          onClose();
+        }
+      },
+      [onClose],
+    );
+
+    useEffect(() => {
+      if (isOpen) {
+        document.addEventListener('keydown', handleEscape);
+        document.body.style.overflow = 'hidden';
+      }
+      return () => {
+        document.removeEventListener('keydown', handleEscape);
+        document.body.style.overflow = 'unset';
+      };
+    }, [isOpen, handleEscape]);
+
+    if (!isOpen) return null;
+
+    return (
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={title ? 'modal-title' : undefined}
+      >
+        {/* Overlay */}
+        <div
+          className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+          onClick={onClose}
+          aria-hidden="true"
+        />
+
+        {/* Modal content */}
+        <div
+          ref={ref}
+          className={cn(
+            'relative z-10 w-full max-w-md mx-4',
+            'bg-[rgb(var(--color-surface))] rounded-lg shadow-xl',
+            'border border-[rgb(var(--color-border))]',
+            'animate-in fade-in zoom-in-95 duration-200',
+            className,
+          )}
+          {...props}
+        >
+          {/* Header */}
+          {title && (
+            <div className="flex items-center justify-between px-6 py-4 border-b border-[rgb(var(--color-border))]">
+              <h2
+                id="modal-title"
+                className="text-lg font-semibold text-[rgb(var(--color-text))]"
+              >
+                {title}
+              </h2>
+              <button
+                onClick={onClose}
+                className="p-1 rounded-md text-[rgb(var(--color-text-muted))] hover:text-[rgb(var(--color-text))] hover:bg-[rgb(var(--color-surface-hover))] transition-colors"
+                aria-label="Fermer"
+              >
+                <svg
+                  className="w-5 h-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+          )}
+
+          {/* Body */}
+          <div className="px-6 py-4">{children}</div>
+        </div>
+      </div>
+    );
+  },
+);
+
+Modal.displayName = 'Modal';
+
+export { Modal, type ModalProps };

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -40,3 +40,6 @@ export type {
   FormGroupProps,
   FormSectionProps,
 } from './FormField';
+
+export { Modal } from './Modal';
+export type { ModalProps } from './Modal';

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,7 +1,19 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui';
+import {
+  DonationModal,
+  BitcoinIcon,
+  EthereumIcon,
+} from '@/components/features/DonationModal';
+
+const BTC_ADDRESS = import.meta.env.VITE_DONATION_BTC;
+const ETH_ADDRESS = import.meta.env.VITE_DONATION_ETH;
 
 export function Landing() {
+  const [isDonationModalOpen, setIsDonationModalOpen] = useState(false);
+  const hasDonationAddresses = BTC_ADDRESS || ETH_ADDRESS;
+
   return (
     <div className="min-h-screen bg-[rgb(var(--color-bg-secondary))]">
       {/* Hero Section */}
@@ -155,11 +167,42 @@ export function Landing() {
       {/* Footer */}
       <footer className="py-8 bg-[rgb(var(--color-bg))] border-t border-[rgb(var(--color-border))]">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <p className="text-center text-sm text-[rgb(var(--color-text-secondary))]">
-            &copy; {new Date().getFullYear()} Crafter. Tous droits réservés.
-          </p>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+            <p className="text-sm text-[rgb(var(--color-text-secondary))]">
+              &copy; {new Date().getFullYear()} Crafter. Tous droits réservés.
+            </p>
+            {hasDonationAddresses && (
+              <div className="flex items-center gap-2">
+                <span className="text-[rgb(var(--color-border))] hidden sm:inline">
+                  |
+                </span>
+                <button
+                  onClick={() => setIsDonationModalOpen(true)}
+                  className="flex items-center gap-2 px-3 py-1.5 rounded-md text-sm text-[rgb(var(--color-text-muted))] hover:text-[rgb(var(--color-text))] hover:bg-[rgb(var(--color-surface-hover))] transition-colors group cursor-pointer"
+                  aria-label="Soutenir le projet"
+                >
+                  {BTC_ADDRESS && (
+                    <span className="transition-transform duration-500 group-hover:rotate-[360deg]">
+                      <BitcoinIcon />
+                    </span>
+                  )}
+                  {ETH_ADDRESS && (
+                    <span className="transition-transform duration-500 group-hover:rotate-[360deg]">
+                      <EthereumIcon />
+                    </span>
+                  )}
+                  <span>Soutenir</span>
+                </button>
+              </div>
+            )}
+          </div>
         </div>
       </footer>
+
+      <DonationModal
+        isOpen={isDonationModalOpen}
+        onClose={() => setIsDonationModalOpen(false)}
+      />
     </div>
   );
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,6 +4,8 @@ interface ImportMetaEnv {
   readonly VITE_API_URL: string;
   readonly VITE_AI_API_KEY?: string;
   readonly VITE_APP_NAME: string;
+  readonly VITE_DONATION_BTC?: string;
+  readonly VITE_DONATION_ETH?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

  Ajout d'une section de dons en cryptomonnaies (Bitcoin et Ethereum) accessible depuis les footers de l'application.

  ### Fonctionnalités
  - Icônes BTC et ETH dans les footers (Landing page + Dashboard)
  - Modal de dons avec adresses copiables en un clic
  - Animation de rotation 360° au survol des icônes
  - Affichage conditionnel : les icônes n'apparaissent que si les adresses sont configurées

  ### Composants créés
  - `Modal.tsx` : Composant modal réutilisable avec accessibilité (Escape, clic overlay, aria)
  - `DonationModal.tsx` : Modal spécifique pour les dons avec icônes et bouton copier

  ### Configuration
  Nouvelles variables d'environnement (optionnelles) :
  ```bash
  VITE_DONATION_BTC=bc1q...
  VITE_DONATION_ETH=0x...

  Documentation

  - Mise à jour de CLAUDE.md, README.md, PROJECT.md
  - Ajout de la documentation Modal dans EXAMPLES.md
  - Correction des routes obsolètes dans CLAUDE.md