### PR TITLE
fix: correct edit button URL on PreviewCRA page

### DIFF
--- a/src/pages/PreviewCRA.tsx
+++ b/src/pages/PreviewCRA.tsx
@@ -190,7 +190,7 @@ export function PreviewCRA() {
           <div className="flex gap-3">
             <Button
               variant="outline"
-              onClick={() => navigate(`/cra/${id}/edit`)}
+              onClick={() => navigate(`/dashboard/cra/${id}/edit`)}
             >
               Éditer
             </Button>


### PR DESCRIPTION
The edit button was navigating to /cra/:id/edit instead of /dashboard/cra/:id/edit, causing a 404 error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)