### PR TITLE
chore(deps): upgrade PostgreSQL from 16 to 18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-version: '3.8'
-
 services:
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     container_name: cra_postgres
     restart: unless-stopped
     ports:


### PR DESCRIPTION
- Update Docker image from postgres:16-alpine to postgres:18-alpine
- Remove deprecated 'version' attribute from docker-compose.yml

PostgreSQL 18 brings performance improvements including async I/O, virtual generated columns, and OAuth authentication support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)