### PR TITLE
fix: use npm install instead of npm ci to avoid cache lock

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,5 @@
+[phases.build]
+cmds = ["npm install && npm run build"]
+
+[phases.install]
+cmds = ["npm install"]


### PR DESCRIPTION
Nixpacks mounts a Docker cache on /app/node_modules/.cache which conflicts with npm ci trying to remove the directory.

Using npm install avoids this EBUSY error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)