### PR TITLE
fix: separate install and build phases in nixpacks config

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,5 +1,6 @@
-[phases.build]
-cmds = ["npm install && npm run build"]
-
 [phases.install]
 cmds = ["npm install"]
+
+[phases.build]
+dependsOn = ["install"]
+cmds = ["npm run build"]


### PR DESCRIPTION
- Use dependsOn to properly chain phases
- Build phase only runs npm run build (not npm ci)
- Install phase handles npm install separately

This prevents the EBUSY cache lock error from npm ci.

🤖 Generated with [Claude Code](https://claude.com/claude-code)