### PR TITLE
fix: disable cache directories in nixpacks phases

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,6 +1,8 @@
 [phases.install]
 cmds = ["npm install"]
+cacheDirectories = []
 
 [phases.build]
 dependsOn = ["install"]
 cmds = ["npm run build"]
+cacheDirectories = []


### PR DESCRIPTION
Add cacheDirectories = [] to both install and build phases to prevent Docker cache mount conflicts with npm ci.

🤖 Generated with [Claude Code](https://claude.com/claude-code)