### PR TITLE
fix: add .js extension to ESM imports in backend services

### DIFF
--- a/backend/src/services/email.service.ts
+++ b/backend/src/services/email.service.ts
@@ -1,5 +1,5 @@
 import { Resend } from 'resend';
-import { emailConfig, emailTemplates } from '../config/email.config';
+import { emailConfig, emailTemplates } from '../config/email.config.js';
 
 // Instance Resend (initialisée seulement si la clé API est configurée)
 let resend: Resend | null = null;

--- a/backend/src/services/token.service.ts
+++ b/backend/src/services/token.service.ts
@@ -1,6 +1,6 @@
 import jwt, { SignOptions } from 'jsonwebtoken';
 import crypto from 'crypto';
-import { jwtConfig } from '../config/jwt.config';
+import { jwtConfig } from '../config/jwt.config.js';
 import type { TokenPayload } from '../types/auth.types';
 
 /**


### PR DESCRIPTION
Node.js ESM requires explicit .js extensions for local imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)