### PR TITLE
fix: prevent double slashes in sitemap and robots.txt URLs

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,7 +19,7 @@ JWT_ACCESS_EXPIRES_IN=15m
 JWT_REFRESH_EXPIRES_IN=7d
 
 # Email Configuration (using Resend)
-EMAIL_FROM=noreply@crafter.app
+EMAIL_FROM=noreply@yourdomain.com
 RESEND_API_KEY=your-resend-api-key
 
 # Frontend URL (for email links)

--- a/src/plugins/vite-plugin-robots.ts
+++ b/src/plugins/vite-plugin-robots.ts
@@ -6,7 +6,8 @@ export function robotsPlugin(): Plugin {
     apply: 'build',
     generateBundle() {
       const isIndexable = process.env.VITE_INDEXABLE === 'true';
-      const siteUrl = process.env.VITE_SITE_URL || '';
+      // Remove trailing slash to avoid double slashes in URLs
+      const siteUrl = (process.env.VITE_SITE_URL || '').replace(/\/$/, '');
 
       let robotsContent: string;
 

--- a/src/plugins/vite-plugin-sitemap.ts
+++ b/src/plugins/vite-plugin-sitemap.ts
@@ -25,7 +25,8 @@ export function sitemapPlugin(): Plugin {
         return;
       }
 
-      const siteUrl = process.env.VITE_SITE_URL || '';
+      // Remove trailing slash to avoid double slashes in URLs
+      const siteUrl = (process.env.VITE_SITE_URL || '').replace(/\/$/, '');
 
       const urls: SitemapUrl[] = [
         { loc: '/', changefreq: 'weekly', priority: 1.0 },


### PR DESCRIPTION
Strip trailing slash from VITE_SITE_URL to avoid malformed URLs like https://example.com//login that cause Google Search Console to reject the sitemap.

Also update .env.example to use generic placeholder for EMAIL_FROM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)