### PR TITLE
fix(security): address security vulnerabilities across frontend and backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,6 @@
 # API Backend URL
 VITE_API_URL=http://localhost:3001/api
 
-# AI API Key (optionnel, pour fonctionnalités d'aide IA)
-VITE_AI_API_KEY=
-
 # Application Name
 VITE_APP_NAME=Crafter
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,6 @@ Le projet utilise des variables d'environnement pour la configuration. Copier `.
 # API Backend URL
 VITE_API_URL=http://localhost:3001/api
 
-# AI API Key (optionnel, pour fonctionnalités d'aide IA)
-VITE_AI_API_KEY=
-
 # Application Name
 VITE_APP_NAME=Crafter
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,6 +9,10 @@ DB_NAME=cra_db
 DB_USER=cra_user
 DB_PASSWORD=cra_password
 
+# Database SSL Configuration
+# Set to 'false' only if your provider uses self-signed certs (e.g. Railway)
+# DB_SSL_REJECT_UNAUTHORIZED=false
+
 # CORS Configuration
 CORS_ORIGIN=http://localhost:5173
 

--- a/backend/migrations/004_add_users.sql
+++ b/backend/migrations/004_add_users.sql
@@ -54,37 +54,13 @@ CREATE TRIGGER update_users_updated_at
   EXECUTE FUNCTION update_updated_at_column();
 
 -- ============================================
--- Utilisateur admin par défaut (optionnel)
--- Mot de passe: admin123 (à changer en production!)
--- ============================================
--- Note: Le hash ci-dessous correspond à 'admin123' avec bcrypt
--- En production, créer l'admin via l'API ou changer ce mot de passe
-INSERT INTO users (
-  email,
-  password_hash,
-  role,
-  first_name,
-  last_name,
-  email_verified
-) VALUES (
-  'admin@crafter.app',
-  '$2b$12$I4GOY9X5k1tqeGAsZ4YcFeJM0btSodSjyFUWx.NHXuV7E.aX9xDkG',
-  'admin',
-  'Admin',
-  'Crafter',
-  true
-);
-
--- ============================================
 -- Affichage du résumé
 -- ============================================
+-- Note: To create an admin user, use the seed script:
+--   npx tsx scripts/create-admin.ts <email> <password>
 \echo ''
 \echo '✓ Migration 004_add_users.sql completed!'
 \echo ''
 \echo 'Table created:'
 \echo '  - users (with 4 indexes and trigger)'
-\echo ''
-\echo 'Default admin user created:'
-\echo '  - Email: admin@crafter.app'
-\echo '  - Password: admin123 (CHANGE IN PRODUCTION!)'
 \echo ''

--- a/backend/migrations/004_add_users.sql
+++ b/backend/migrations/004_add_users.sql
@@ -54,13 +54,37 @@ CREATE TRIGGER update_users_updated_at
   EXECUTE FUNCTION update_updated_at_column();
 
 -- ============================================
+-- Utilisateur admin par défaut (optionnel)
+-- Mot de passe: admin123 (à changer en production!)
+-- ============================================
+-- Note: Le hash ci-dessous correspond à 'admin123' avec bcrypt
+-- En production, créer l'admin via l'API ou changer ce mot de passe
+INSERT INTO users (
+  email,
+  password_hash,
+  role,
+  first_name,
+  last_name,
+  email_verified
+) VALUES (
+  'admin@crafter.app',
+  '$2b$12$I4GOY9X5k1tqeGAsZ4YcFeJM0btSodSjyFUWx.NHXuV7E.aX9xDkG',
+  'admin',
+  'Admin',
+  'Crafter',
+  true
+);
+
+-- ============================================
 -- Affichage du résumé
 -- ============================================
--- Note: To create an admin user, use the seed script:
---   npx tsx scripts/create-admin.ts <email> <password>
 \echo ''
 \echo '✓ Migration 004_add_users.sql completed!'
 \echo ''
 \echo 'Table created:'
 \echo '  - users (with 4 indexes and trigger)'
+\echo ''
+\echo 'Default admin user created:'
+\echo '  - Email: admin@crafter.app'
+\echo '  - Password: admin123 (CHANGE IN PRODUCTION!)'
 \echo ''

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,6 +16,7 @@
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
+        "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.3",
         "multer": "^2.0.2",
         "nodemailer": "^8.0.0",
@@ -2195,6 +2196,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,7 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.3",
     "express": "^5.2.1",
+    "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.3",
     "multer": "^2.0.2",
     "nodemailer": "^8.0.0",

--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -17,10 +17,11 @@ export const pool = new Pool({
         user: process.env.DB_USER || 'cra_user',
         password: process.env.DB_PASSWORD || 'cra_password',
       }),
-  // SSL requis en production (Railway)
+  // SSL requis en production
+  // Set DB_SSL_REJECT_UNAUTHORIZED=false only for providers with self-signed certs (e.g. Railway)
   ssl:
     process.env.NODE_ENV === 'production'
-      ? { rejectUnauthorized: false }
+      ? { rejectUnauthorized: process.env.DB_SSL_REJECT_UNAUTHORIZED !== 'false' }
       : false,
   max: 20,
   idleTimeoutMillis: 30000,

--- a/backend/src/config/email.config.ts
+++ b/backend/src/config/email.config.ts
@@ -1,5 +1,14 @@
 // Configuration Email (Resend)
 
+function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
 export const emailConfig = {
   from: process.env.EMAIL_FROM || 'noreply@crafter.app',
   resendApiKey: process.env.RESEND_API_KEY || '',
@@ -11,7 +20,7 @@ export const emailTemplates = {
   verification: {
     subject: 'Vérifiez votre adresse email - Crafter',
     getBody: (verificationUrl: string, firstName?: string): string => `
-      <h1>Bienvenue sur Crafter${firstName ? `, ${firstName}` : ''} !</h1>
+      <h1>Bienvenue sur Crafter${firstName ? `, ${escapeHtml(firstName)}` : ''} !</h1>
       <p>Merci de vous être inscrit. Veuillez cliquer sur le lien ci-dessous pour vérifier votre adresse email :</p>
       <p><a href="${verificationUrl}" style="display: inline-block; padding: 12px 24px; background-color: #6366f1; color: white; text-decoration: none; border-radius: 8px;">Vérifier mon email</a></p>
       <p>Ce lien expire dans 24 heures.</p>
@@ -23,7 +32,7 @@ export const emailTemplates = {
     subject: 'Réinitialisation de votre mot de passe - Crafter',
     getBody: (resetUrl: string, firstName?: string): string => `
       <h1>Réinitialisation de mot de passe</h1>
-      <p>Bonjour${firstName ? ` ${firstName}` : ''},</p>
+      <p>Bonjour${firstName ? ` ${escapeHtml(firstName)}` : ''},</p>
       <p>Vous avez demandé à réinitialiser votre mot de passe. Cliquez sur le lien ci-dessous :</p>
       <p><a href="${resetUrl}" style="display: inline-block; padding: 12px 24px; background-color: #6366f1; color: white; text-decoration: none; border-radius: 8px;">Réinitialiser mon mot de passe</a></p>
       <p>Ce lien expire dans 1 heure.</p>
@@ -34,7 +43,7 @@ export const emailTemplates = {
   welcome: {
     subject: 'Bienvenue sur Crafter !',
     getBody: (firstName?: string): string => `
-      <h1>Bienvenue sur Crafter${firstName ? `, ${firstName}` : ''} !</h1>
+      <h1>Bienvenue sur Crafter${firstName ? `, ${escapeHtml(firstName)}` : ''} !</h1>
       <p>Votre compte a été créé avec succès et votre email est maintenant vérifié.</p>
       <p>Vous pouvez maintenant :</p>
       <ul>

--- a/backend/src/config/jwt.config.ts
+++ b/backend/src/config/jwt.config.ts
@@ -1,8 +1,18 @@
 // Configuration JWT
 
+const accessSecret = process.env.JWT_ACCESS_SECRET;
+const refreshSecret = process.env.JWT_REFRESH_SECRET;
+
+if (!accessSecret || !refreshSecret) {
+  throw new Error(
+    'FATAL: JWT_ACCESS_SECRET and JWT_REFRESH_SECRET environment variables must be set. ' +
+      "Generate secure values with: node -e \"console.log(require('crypto').randomBytes(64).toString('hex'))\"",
+  );
+}
+
 export const jwtConfig = {
-  accessSecret: process.env.JWT_ACCESS_SECRET || 'default-access-secret-change-in-production',
-  refreshSecret: process.env.JWT_REFRESH_SECRET || 'default-refresh-secret-change-in-production',
+  accessSecret,
+  refreshSecret,
   accessExpiresIn: process.env.JWT_ACCESS_EXPIRES_IN || '15m',
   refreshExpiresIn: process.env.JWT_REFRESH_EXPIRES_IN || '7d',
 };

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -15,7 +15,7 @@ import type {
 // Configuration du cookie refresh token
 const REFRESH_COOKIE_OPTIONS = {
   httpOnly: true,
-  secure: process.env.NODE_ENV === 'production',
+  secure: process.env.NODE_ENV !== 'development',
   sameSite: 'strict' as const,
   maxAge: getRefreshTokenMaxAge(),
   path: '/api/auth',

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -97,7 +97,7 @@ export class AuthController {
       // Envoyer l'email de vérification
       await EmailService.sendVerificationEmail(user.email, verificationToken, user.first_name || undefined);
 
-      console.log(`[Auth] User registered: ${user.email}`);
+      console.log(`[Auth] User registered: ${user.id}`);
 
       res.status(201).json({
         success: true,
@@ -197,7 +197,7 @@ export class AuthController {
       // Définir le cookie refresh token
       res.cookie('refreshToken', refreshToken, REFRESH_COOKIE_OPTIONS);
 
-      console.log(`[Auth] User logged in: ${user.email}`);
+      console.log(`[Auth] User logged in: ${user.id}`);
 
       res.json({
         success: true,
@@ -225,7 +225,7 @@ export class AuthController {
       if (req.user) {
         // Supprimer le refresh token de la base
         await UserModel.setRefreshToken(req.user.id, null);
-        console.log(`[Auth] User logged out: ${req.user.email}`);
+        console.log(`[Auth] User logged out: ${req.user.id}`);
       }
 
       // Supprimer le cookie
@@ -360,7 +360,7 @@ export class AuthController {
       // Envoyer l'email de bienvenue
       await EmailService.sendWelcomeEmail(user.email, user.first_name || undefined);
 
-      console.log(`[Auth] Email verified: ${user.email}`);
+      console.log(`[Auth] Email verified: ${user.id}`);
 
       res.json({
         success: true,
@@ -476,7 +476,7 @@ export class AuthController {
       await UserModel.setResetToken(user.id, tokenHash, tokenExpires);
       await EmailService.sendPasswordResetEmail(user.email, resetToken, user.first_name || undefined);
 
-      console.log(`[Auth] Password reset requested: ${user.email}`);
+      console.log(`[Auth] Password reset requested: ${user.id}`);
 
       res.json({ success: true, message: successMessage });
     } catch (error) {
@@ -538,7 +538,7 @@ export class AuthController {
       // Invalider tous les refresh tokens existants
       await UserModel.setRefreshToken(user.id, null);
 
-      console.log(`[Auth] Password reset successful: ${user.email}`);
+      console.log(`[Auth] Password reset successful: ${user.id}`);
 
       res.json({
         success: true,
@@ -699,7 +699,7 @@ export class AuthController {
       // Invalider tous les refresh tokens (force re-login)
       await UserModel.setRefreshToken(req.user.id, null);
 
-      console.log(`[Auth] Password changed: ${req.user.email}`);
+      console.log(`[Auth] Password changed: ${req.user.id}`);
 
       res.json({
         success: true,

--- a/backend/src/routes/upload.routes.ts
+++ b/backend/src/routes/upload.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import { uploadSignature } from '../config/upload.config.js';
 import { uploadSignatureImage } from '../controllers/upload.controller.js';
+import { authenticate } from '../middleware/auth.middleware.js';
 
 const router = Router();
 
@@ -12,6 +13,7 @@ const router = Router();
  */
 router.post(
   '/signature',
+  authenticate,
   uploadSignature.single('signature'),
   uploadSignatureImage,
 );

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,4 +1,5 @@
 import express, { Request, Response, NextFunction } from 'express';
+import helmet from 'helmet';
 import cors from 'cors';
 import dotenv from 'dotenv';
 import cookieParser from 'cookie-parser';
@@ -13,6 +14,9 @@ dotenv.config();
 
 const app = express();
 const PORT = process.env.PORT || 3001;
+
+// Security headers
+app.use(helmet());
 
 // Middleware CORS
 app.use(

--- a/backend/src/services/email.service.ts
+++ b/backend/src/services/email.service.ts
@@ -54,7 +54,7 @@ export class EmailService {
         return false;
       }
 
-      console.log(`[Email] Email sent successfully to ${options.to}`);
+      console.log('[Email] Email sent successfully');
       return true;
     } catch (error) {
       console.error('[Email] Error sending email:', error);

--- a/src/lib/token-store.ts
+++ b/src/lib/token-store.ts
@@ -1,0 +1,13 @@
+/**
+ * In-memory token store for access tokens.
+ * Avoids persisting tokens to localStorage (XSS risk).
+ * Session recovery relies on the httpOnly refresh token cookie.
+ */
+let currentAccessToken: string | null = null;
+
+export const tokenStore = {
+  get: (): string | null => currentAccessToken,
+  set: (token: string | null) => {
+    currentAccessToken = token;
+  },
+};

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,25 +2,17 @@
  * Configuration de l'API et fonctions utilitaires pour les requêtes HTTP
  */
 
+import { tokenStore } from '@/lib/token-store';
+
 // Configuration de l'API
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001/api';
 const APP_NAME = import.meta.env.VITE_APP_NAME || 'Crafter';
 
 /**
- * Fonction pour récupérer le token d'accès depuis le localStorage
- * Évite la dépendance circulaire avec le store
+ * Fonction pour récupérer le token d'accès depuis le store en mémoire
  */
 export const getAccessToken = (): string | null => {
-  try {
-    const stored = localStorage.getItem('crafter-auth-storage');
-    if (stored) {
-      const parsed = JSON.parse(stored);
-      return parsed.state?.accessToken || null;
-    }
-  } catch {
-    // Ignorer les erreurs de parsing
-  }
-  return null;
+  return tokenStore.get();
 };
 
 /**

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -10,7 +10,7 @@ const APP_NAME = import.meta.env.VITE_APP_NAME || 'Crafter';
  * Fonction pour récupérer le token d'accès depuis le localStorage
  * Évite la dépendance circulaire avec le store
  */
-const getAccessToken = (): string | null => {
+export const getAccessToken = (): string | null => {
   try {
     const stored = localStorage.getItem('crafter-auth-storage');
     if (stored) {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -4,7 +4,6 @@
 
 // Configuration de l'API
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001/api';
-const AI_API_KEY = import.meta.env.VITE_AI_API_KEY;
 const APP_NAME = import.meta.env.VITE_APP_NAME || 'Crafter';
 
 /**
@@ -186,7 +185,6 @@ export function unwrapApiResponse<T>(
  */
 export const env = {
   apiUrl: API_URL,
-  aiApiKey: AI_API_KEY,
   appName: APP_NAME,
   isDev: import.meta.env.DEV,
   isProd: import.meta.env.PROD,

--- a/src/services/upload.service.ts
+++ b/src/services/upload.service.ts
@@ -1,4 +1,4 @@
-import { env } from './api';
+import { env, getAccessToken } from './api';
 
 /**
  * Upload une image de signature
@@ -9,9 +9,15 @@ export async function uploadSignature(file: File): Promise<string> {
   const formData = new FormData();
   formData.append('signature', file);
 
+  const accessToken = getAccessToken();
+
   const response = await fetch(`${env.apiUrl}/upload/signature`, {
     method: 'POST',
     body: formData,
+    credentials: 'include',
+    headers: {
+      ...(accessToken && { Authorization: `Bearer ${accessToken}` }),
+    },
   });
 
   if (!response.ok) {

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 import { authService } from '@/services/auth.service';
+import { tokenStore } from '@/lib/token-store';
 import type {
   User,
   LoginCredentials,
@@ -29,202 +29,187 @@ interface AuthState {
   initialize: () => Promise<void>;
 }
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set, get) => ({
-      // État initial
-      user: null,
-      accessToken: null,
-      isAuthenticated: false,
-      isLoading: false,
-      isInitialized: false,
-      error: null,
+export const useAuthStore = create<AuthState>()((set, get) => ({
+  // État initial
+  user: null,
+  accessToken: null,
+  isAuthenticated: false,
+  isLoading: false,
+  isInitialized: false,
+  error: null,
 
-      // Connexion
-      login: async (credentials) => {
-        set({ isLoading: true, error: null });
+  // Connexion
+  login: async (credentials) => {
+    set({ isLoading: true, error: null });
 
-        try {
-          const response = await authService.login(credentials);
+    try {
+      const response = await authService.login(credentials);
 
-          set({
-            user: response.user,
-            accessToken: response.accessToken,
-            isAuthenticated: true,
-            isLoading: false,
-            error: null,
-          });
+      tokenStore.set(response.accessToken);
+      set({
+        user: response.user,
+        accessToken: response.accessToken,
+        isAuthenticated: true,
+        isLoading: false,
+        error: null,
+      });
 
-          console.log('[Auth Store] User logged in');
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : 'Échec de la connexion';
+      console.log('[Auth Store] User logged in');
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Échec de la connexion';
 
-          set({
-            user: null,
-            accessToken: null,
-            isAuthenticated: false,
-            isLoading: false,
-            error: message,
-          });
+      tokenStore.set(null);
+      set({
+        user: null,
+        accessToken: null,
+        isAuthenticated: false,
+        isLoading: false,
+        error: message,
+      });
 
-          throw error;
-        }
-      },
+      throw error;
+    }
+  },
 
-      // Inscription
-      register: async (data) => {
-        set({ isLoading: true, error: null });
+  // Inscription
+  register: async (data) => {
+    set({ isLoading: true, error: null });
 
-        try {
-          await authService.register(data);
-          set({ isLoading: false, error: null });
-          console.log('[Auth Store] User registered');
-        } catch (error) {
-          const message =
-            error instanceof Error ? error.message : "Échec de l'inscription";
+    try {
+      await authService.register(data);
+      set({ isLoading: false, error: null });
+      console.log('[Auth Store] User registered');
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Échec de l'inscription";
 
-          set({ isLoading: false, error: message });
-          throw error;
-        }
-      },
+      set({ isLoading: false, error: message });
+      throw error;
+    }
+  },
 
-      // Déconnexion
-      logout: async () => {
-        try {
-          await authService.logout();
-        } catch (error) {
-          console.error('[Auth Store] Logout error:', error);
-        } finally {
-          set({
-            user: null,
-            accessToken: null,
-            isAuthenticated: false,
-            error: null,
-          });
-          console.log('[Auth Store] User logged out');
-        }
-      },
+  // Déconnexion
+  logout: async () => {
+    try {
+      await authService.logout();
+    } catch (error) {
+      console.error('[Auth Store] Logout error:', error);
+    } finally {
+      tokenStore.set(null);
+      set({
+        user: null,
+        accessToken: null,
+        isAuthenticated: false,
+        error: null,
+      });
+      console.log('[Auth Store] User logged out');
+    }
+  },
 
-      // Rafraîchir l'authentification
-      refreshAuth: async () => {
-        try {
-          const response = await authService.refreshToken();
+  // Rafraîchir l'authentification
+  refreshAuth: async () => {
+    try {
+      const response = await authService.refreshToken();
 
-          set({
-            user: response.user,
-            accessToken: response.accessToken,
-            isAuthenticated: true,
-          });
+      tokenStore.set(response.accessToken);
+      set({
+        user: response.user,
+        accessToken: response.accessToken,
+        isAuthenticated: true,
+      });
 
-          console.log('[Auth Store] Auth refreshed');
-          return true;
-        } catch (error) {
-          console.error('[Auth Store] Refresh failed:', error);
+      console.log('[Auth Store] Auth refreshed');
+      return true;
+    } catch (error) {
+      console.error('[Auth Store] Refresh failed:', error);
 
-          set({
-            user: null,
-            accessToken: null,
-            isAuthenticated: false,
-          });
+      tokenStore.set(null);
+      set({
+        user: null,
+        accessToken: null,
+        isAuthenticated: false,
+      });
 
-          return false;
-        }
-      },
+      return false;
+    }
+  },
 
-      // Mettre à jour le profil
-      updateProfile: async (data) => {
-        set({ isLoading: true, error: null });
+  // Mettre à jour le profil
+  updateProfile: async (data) => {
+    set({ isLoading: true, error: null });
 
-        try {
-          const updatedUser = await authService.updateProfile(data);
+    try {
+      const updatedUser = await authService.updateProfile(data);
 
-          set({
-            user: updatedUser,
-            isLoading: false,
-            error: null,
-          });
+      set({
+        user: updatedUser,
+        isLoading: false,
+        error: null,
+      });
 
-          console.log('[Auth Store] Profile updated');
-        } catch (error) {
-          const message =
-            error instanceof Error
-              ? error.message
-              : 'Échec de la mise à jour du profil';
+      console.log('[Auth Store] Profile updated');
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Échec de la mise à jour du profil';
 
-          set({ isLoading: false, error: message });
-          throw error;
-        }
-      },
+      set({ isLoading: false, error: message });
+      throw error;
+    }
+  },
 
-      // Setters
-      setAccessToken: (token) => set({ accessToken: token }),
+  // Setters
+  setAccessToken: (token) => {
+    tokenStore.set(token);
+    set({ accessToken: token });
+  },
 
-      setUser: (user) =>
-        set({
-          user,
-          isAuthenticated: !!user,
-        }),
-
-      clearError: () => set({ error: null }),
-
-      // Initialiser l'authentification au démarrage
-      initialize: async () => {
-        const { accessToken, isInitialized } = get();
-
-        // Ne pas initialiser deux fois
-        if (isInitialized) return;
-
-        set({ isLoading: true });
-
-        try {
-          // Si on a un token, essayer de récupérer l'utilisateur
-          if (accessToken) {
-            const user = await authService.getCurrentUser();
-            set({
-              user,
-              isAuthenticated: true,
-              isLoading: false,
-              isInitialized: true,
-            });
-            console.log('[Auth Store] Initialized with existing session');
-            return;
-          }
-
-          // Sinon, essayer de rafraîchir via le cookie
-          const success = await get().refreshAuth();
-
-          set({
-            isLoading: false,
-            isInitialized: true,
-          });
-
-          if (success) {
-            console.log('[Auth Store] Initialized via refresh token');
-          } else {
-            console.log('[Auth Store] No valid session found');
-          }
-        } catch (error) {
-          console.error('[Auth Store] Initialization error:', error);
-          set({
-            user: null,
-            accessToken: null,
-            isAuthenticated: false,
-            isLoading: false,
-            isInitialized: true,
-          });
-        }
-      },
+  setUser: (user) =>
+    set({
+      user,
+      isAuthenticated: !!user,
     }),
-    {
-      name: 'crafter-auth-storage',
-      // Ne persister que le token (pas l'utilisateur complet pour la sécurité)
-      partialize: (state) => ({
-        accessToken: state.accessToken,
-      }),
-    },
-  ),
-);
+
+  clearError: () => set({ error: null }),
+
+  // Initialiser l'authentification au démarrage
+  initialize: async () => {
+    const { isInitialized } = get();
+
+    // Ne pas initialiser deux fois
+    if (isInitialized) return;
+
+    set({ isLoading: true });
+
+    try {
+      // Essayer de rafraîchir via le cookie httpOnly
+      const success = await get().refreshAuth();
+
+      set({
+        isLoading: false,
+        isInitialized: true,
+      });
+
+      if (success) {
+        console.log('[Auth Store] Initialized via refresh token');
+      } else {
+        console.log('[Auth Store] No valid session found');
+      }
+    } catch (error) {
+      console.error('[Auth Store] Initialization error:', error);
+      tokenStore.set(null);
+      set({
+        user: null,
+        accessToken: null,
+        isAuthenticated: false,
+        isLoading: false,
+        isInitialized: true,
+      });
+    }
+  },
+}));
 
 // Hook helper pour vérifier si l'utilisateur est admin
 export const useIsAdmin = () => {

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -55,7 +55,7 @@ export const useAuthStore = create<AuthState>()(
             error: null,
           });
 
-          console.log('[Auth Store] User logged in:', response.user.email);
+          console.log('[Auth Store] User logged in');
         } catch (error) {
           const message =
             error instanceof Error ? error.message : 'Échec de la connexion';
@@ -79,7 +79,7 @@ export const useAuthStore = create<AuthState>()(
         try {
           await authService.register(data);
           set({ isLoading: false, error: null });
-          console.log('[Auth Store] User registered:', data.email);
+          console.log('[Auth Store] User registered');
         } catch (error) {
           const message =
             error instanceof Error ? error.message : "Échec de l'inscription";

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,7 +2,6 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_URL: string;
-  readonly VITE_AI_API_KEY?: string;
   readonly VITE_APP_NAME: string;
   readonly VITE_DONATION_BTC?: string;
   readonly VITE_DONATION_ETH?: string;


### PR DESCRIPTION
## Summary

- **Sanitize HTML in email templates** — prevent stored XSS via malicious `firstName` during registration
- **Remove AI API key from client bundle** — `VITE_AI_API_KEY` was exported in the frontend JS, visible to anyone
- **Require authentication for signature upload** — add `authenticate` middleware on backend + credentials/token on frontend
- **Require JWT secrets via environment variables** — throw at startup instead of falling back to predictable defaults
- **Enable SSL certificate verification for PostgreSQL** — default `rejectUnauthorized` to `true` in production
- **Remove PII (emails) from logs** — replace email addresses with user IDs in backend and frontend logs
- **Default cookie secure flag to true** — only disable in explicit `development` mode
- **Store access token in memory instead of localStorage** — reduce XSS attack surface, rely on httpOnly refresh cookie
- **Add helmet middleware** — set standard HTTP security headers on all backend responses

## Breaking changes

- **JWT secrets required**: The backend will refuse to start without `JWT_ACCESS_SECRET` and `JWT_REFRESH_SECRET` environment variables
- **Session persistence**: Users will need to re-login after deploy (access token is no longer persisted in localStorage; session recovery uses the httpOnly refresh cookie)
- **SSL verification**: Production deployments using self-signed DB certs must set `DB_SSL_REJECT_UNAUTHORIZED=false`

## Test plan

- [ ] Vérifier que le backend démarre avec les variables JWT configurées
- [ ] Vérifier que le backend refuse de démarrer sans les variables JWT
- [ ] Tester login/logout/refresh — la session doit se restaurer via le cookie après rafraîchissement de page
- [ ] Tester l'upload de signature (doit fonctionner connecté, échouer déconnecté)
- [ ] Vérifier les headers de sécurité avec `curl -I` sur un endpoint
- [ ] Vérifier qu'un `firstName` contenant du HTML est échappé dans les emails
- [ ] Vérifier que `aiApiKey` n'apparaît plus dans le bundle JS (`npm run build` puis grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)