### PR TITLE
feat(cra): add fixed signature date with incremental migration tooling

### DIFF
--- a/backend/migrations/008_add_signature_date.sql
+++ b/backend/migrations/008_add_signature_date.sql
@@ -1,0 +1,16 @@
+-- Migration: Add fixed signature date fields
+-- Date: 2026-05-24
+-- Description: Adds an optional fixed signature date per CRA (client + provider).
+--              Combined with use_current_date, this gives three modes:
+--              - Auto:  use_current_date=true,  signature_date=NULL  -> today at PDF export
+--              - Fixed: use_current_date=false, signature_date=<DATE> -> that date
+--              - Empty: use_current_date=false, signature_date=NULL  -> blank line to fill by hand
+
+ALTER TABLE cras
+ADD COLUMN client_signature_date DATE;
+
+ALTER TABLE cras
+ADD COLUMN provider_signature_date DATE;
+
+COMMENT ON COLUMN cras.client_signature_date IS 'Date fixe de signature client (NULL si Auto ou Vide)';
+COMMENT ON COLUMN cras.provider_signature_date IS 'Date fixe de signature prestataire (NULL si Auto ou Vide)';

--- a/backend/migrations/_bootstrap.sql
+++ b/backend/migrations/_bootstrap.sql
@@ -1,0 +1,86 @@
+-- Bootstrap intelligent du tracking des migrations.
+--
+-- Quand on bascule sur une nouvelle branche, la table `schema_migrations`
+-- peut être vide alors que la DB a déjà reçu d'anciennes migrations à la main
+-- (ou via run-all.sh). Si on essayait juste de tout rejouer, ça échouerait
+-- (colonnes déjà existantes, etc.).
+--
+-- Ce script détecte les migrations dont l'empreinte est déjà présente dans
+-- le schéma actuel et les marque comme appliquées, sans toucher au schéma.
+-- Les migrations vraiment nouvelles seront appliquées normalement par
+-- migrate.sh ensuite.
+--
+-- Idempotent : ne fait rien si schema_migrations contient déjà des entrées.
+
+DO $$
+BEGIN
+  -- Ne bootstrap que la première fois (tracking vide)
+  IF EXISTS (SELECT 1 FROM schema_migrations LIMIT 1) THEN
+    RETURN;
+  END IF;
+
+  -- 002 : ajout des champs signature (default_signatory_name sur companies)
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'companies' AND column_name = 'default_signatory_name'
+  ) THEN
+    INSERT INTO schema_migrations (filename) VALUES ('002_add_signature_fields.sql');
+  END IF;
+
+  -- 003 : ajout signature_location/use_current_date (client_signature_location sur cras)
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'cras' AND column_name = 'client_signature_location'
+  ) THEN
+    INSERT INTO schema_migrations (filename) VALUES ('003_add_signature_location_date.sql');
+  END IF;
+
+  -- 004 : création de la table users
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables WHERE table_name = 'users'
+  ) THEN
+    INSERT INTO schema_migrations (filename) VALUES ('004_add_users.sql');
+  END IF;
+
+  -- 005 : ajout user_id sur cras
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'cras' AND column_name = 'user_id'
+  ) THEN
+    INSERT INTO schema_migrations (filename) VALUES ('005_add_user_ownership.sql');
+  END IF;
+
+  -- 006 : suppression de google_id sur users (table users existe ET colonne absente)
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables WHERE table_name = 'users'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'users' AND column_name = 'google_id'
+  ) THEN
+    INSERT INTO schema_migrations (filename) VALUES ('006_remove_google_auth.sql');
+  END IF;
+
+  -- 007 : signatures en base64 (client_signature_image passe de VARCHAR à TEXT)
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'cras'
+      AND column_name = 'client_signature_image'
+      AND data_type = 'text'
+  ) THEN
+    INSERT INTO schema_migrations (filename) VALUES ('007_signatures_base64.sql');
+  END IF;
+
+  -- 008 : date fixe de signature (client_signature_date sur cras)
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'cras' AND column_name = 'client_signature_date'
+  ) THEN
+    INSERT INTO schema_migrations (filename) VALUES ('008_add_signature_date.sql');
+  END IF;
+
+  -- Log si au moins une migration a été backfillée
+  IF EXISTS (SELECT 1 FROM schema_migrations LIMIT 1) THEN
+    RAISE NOTICE 'Bootstrap : % migration(s) détectée(s) comme déjà appliquée(s) dans le schéma',
+      (SELECT COUNT(*) FROM schema_migrations);
+  END IF;
+END $$;

--- a/backend/migrations/migrate.sh
+++ b/backend/migrations/migrate.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+# Applique les migrations incrémentales (NNN_*.sql) qui n'ont pas encore été
+# exécutées. Idempotent : peut être lancé à chaque déploiement / démarrage.
+#
+# Usage:
+#   bash backend/migrations/migrate.sh          # via docker exec (défaut local)
+#   USE_DOCKER=false bash migrate.sh            # via psql local
+#   DB_HOST=… DB_USER=… DB_NAME=… bash migrate.sh
+#
+# Le tracking se fait via la table `schema_migrations` (créée automatiquement).
+# `schema.sql` est intentionnellement ignoré (c'est le bootstrap initial,
+# géré séparément par start-dev.sh / run-all.sh).
+
+set -euo pipefail
+
+# Couleurs
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+# Config
+DB_HOST="${DB_HOST:-localhost}"
+DB_USER="${DB_USER:-cra_user}"
+DB_NAME="${DB_NAME:-cra_db}"
+USE_DOCKER="${USE_DOCKER:-true}"
+DOCKER_CONTAINER="${DOCKER_CONTAINER:-cra_postgres}"
+MIGRATIONS_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Helper psql : route via docker exec ou psql local
+psql_exec() {
+  if [ "$USE_DOCKER" = "true" ]; then
+    docker exec -i "$DOCKER_CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1 "$@"
+  else
+    psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1 "$@"
+  fi
+}
+
+echo -e "${BLUE}=== Migrations incrémentales ===${NC}"
+echo -e "Database: ${DB_NAME} @ ${DB_HOST} (docker=${USE_DOCKER})"
+echo ""
+
+# 1. Créer la table de tracking si elle n'existe pas
+psql_exec <<'SQL' > /dev/null
+CREATE TABLE IF NOT EXISTS schema_migrations (
+  filename    TEXT PRIMARY KEY,
+  applied_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+SQL
+
+# 2. Bootstrap : si on vient juste de créer schema_migrations sur une DB qui
+#    a déjà reçu d'anciennes migrations à la main, on les marque comme
+#    appliquées en détectant leur empreinte dans le schéma. Idempotent.
+psql_exec < "$MIGRATIONS_DIR/_bootstrap.sql"
+
+# 3. Récupérer la liste des migrations déjà appliquées
+APPLIED=$(psql_exec -tAc "SELECT filename FROM schema_migrations ORDER BY filename;")
+
+# 3. Parcourir les fichiers NNN_*.sql triés
+shopt -s nullglob
+MIGRATION_FILES=("$MIGRATIONS_DIR"/[0-9][0-9][0-9]_*.sql)
+
+if [ ${#MIGRATION_FILES[@]} -eq 0 ]; then
+  echo -e "${YELLOW}Aucun fichier de migration trouvé.${NC}"
+  exit 0
+fi
+
+APPLIED_COUNT=0
+SKIPPED_COUNT=0
+
+for file in "${MIGRATION_FILES[@]}"; do
+  filename=$(basename "$file")
+
+  if echo "$APPLIED" | grep -qx "$filename"; then
+    echo -e "${YELLOW}↷ skip${NC}    $filename (déjà appliquée)"
+    SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+    continue
+  fi
+
+  echo -e "${BLUE}→ apply${NC}   $filename"
+
+  # Wrapper la migration dans une transaction : si quoi que ce soit échoue,
+  # rien n'est commité, et schema_migrations n'est pas mis à jour.
+  if {
+    echo "BEGIN;"
+    cat "$file"
+    echo ""
+    echo "INSERT INTO schema_migrations (filename) VALUES ('$filename');"
+    echo "COMMIT;"
+  } | psql_exec > /dev/null; then
+    echo -e "${GREEN}✓ done${NC}    $filename"
+    APPLIED_COUNT=$((APPLIED_COUNT + 1))
+  else
+    echo -e "${RED}✗ FAILED${NC}  $filename"
+    echo -e "${RED}Migration interrompue. Corrige le fichier et relance.${NC}"
+    exit 1
+  fi
+done
+
+echo ""
+echo -e "${GREEN}=== Terminé : ${APPLIED_COUNT} appliquée(s), ${SKIPPED_COUNT} ignorée(s) ===${NC}"

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
     "build": "tsc",
     "start": "node dist/server.js",
     "db:migrate": "bash migrations/run-all.sh",
+    "db:upgrade": "bash migrations/migrate.sh",
     "lint": "eslint src",
     "format": "prettier --write \"src/**/*.ts\""
   },

--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -3,7 +3,14 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const { Pool } = pg;
+const { Pool, types } = pg;
+
+// PostgreSQL DATE (OID 1082) est sémantiquement une date civile sans timezone.
+// Par défaut, node-pg le convertit en Date en heure locale, qui devient décalé
+// d'un jour à la sérialisation JSON UTC (ex. stocké 2026-01-31 → renvoyé
+// "2026-01-30T23:00:00.000Z" pour un process en Europe/Paris). On préfère
+// renvoyer la chaîne YYYY-MM-DD telle quelle pour éviter ce décalage.
+types.setTypeParser(1082, (val: string) => val);
 
 // Configuration de la connexion PostgreSQL
 // Supporte DATABASE_URL (Railway/production) ou variables séparées (dev local)
@@ -21,7 +28,10 @@ export const pool = new Pool({
   // Set DB_SSL_REJECT_UNAUTHORIZED=false only for providers with self-signed certs (e.g. Railway)
   ssl:
     process.env.NODE_ENV === 'production'
-      ? { rejectUnauthorized: process.env.DB_SSL_REJECT_UNAUTHORIZED !== 'false' }
+      ? {
+          rejectUnauthorized:
+            process.env.DB_SSL_REJECT_UNAUTHORIZED !== 'false',
+        }
       : false,
   max: 20,
   idleTimeoutMillis: 30000,

--- a/backend/src/controllers/cra.controller.ts
+++ b/backend/src/controllers/cra.controller.ts
@@ -6,6 +6,25 @@ import {
   CRAFilters,
 } from '../types/cra.types.js';
 
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Valide qu'une valeur est une date ISO YYYY-MM-DD valide, ou null/undefined.
+ * Retourne true si OK, false sinon.
+ */
+function isValidIsoDateOrNullish(value: unknown): boolean {
+  if (value === null || value === undefined || value === '') return true;
+  if (typeof value !== 'string') return false;
+  if (!ISO_DATE_REGEX.test(value)) return false;
+  const [y, m, d] = value.split('-').map(Number);
+  const date = new Date(Date.UTC(y, m - 1, d));
+  return (
+    date.getUTCFullYear() === y &&
+    date.getUTCMonth() === m - 1 &&
+    date.getUTCDate() === d
+  );
+}
+
 /**
  * Helper pour obtenir le user_id à filtrer
  * Retourne undefined pour les admins (qui voient tout)
@@ -177,6 +196,18 @@ export class CRAController {
         return;
       }
 
+      if (
+        !isValidIsoDateOrNullish(req.body.client_signature_date) ||
+        !isValidIsoDateOrNullish(req.body.provider_signature_date)
+      ) {
+        res.status(400).json({
+          success: false,
+          error: 'Invalid signature date',
+          message: 'La date de signature doit être au format YYYY-MM-DD',
+        });
+        return;
+      }
+
       const craData: CreateCRAInput = {
         user_id: req.user.id,
         month,
@@ -192,6 +223,7 @@ export class CRAController {
         client_signature_location:
           req.body.client_signature_location || undefined,
         client_use_current_date: req.body.client_use_current_date ?? undefined,
+        client_signature_date: req.body.client_signature_date || undefined,
         provider_signatory_name: req.body.provider_signatory_name || undefined,
         provider_signatory_title:
           req.body.provider_signatory_title || undefined,
@@ -201,6 +233,7 @@ export class CRAController {
           req.body.provider_signature_location || undefined,
         provider_use_current_date:
           req.body.provider_use_current_date ?? undefined,
+        provider_signature_date: req.body.provider_signature_date || undefined,
       };
 
       const newCRA = await CRAModel.create(craData);
@@ -334,14 +367,44 @@ export class CRAController {
           req.body.client_signature_location || null;
       if (req.body.client_use_current_date !== undefined)
         updateData.client_use_current_date = req.body.client_use_current_date;
+      if (req.body.client_signature_date !== undefined) {
+        if (!isValidIsoDateOrNullish(req.body.client_signature_date)) {
+          res.status(400).json({
+            success: false,
+            error: 'Invalid signature date',
+            message:
+              'La date de signature client doit être au format YYYY-MM-DD',
+          });
+          return;
+        }
+        updateData.client_signature_date =
+          req.body.client_signature_date || null;
+      }
       if (req.body.provider_signature_location !== undefined)
         updateData.provider_signature_location =
           req.body.provider_signature_location || null;
       if (req.body.provider_use_current_date !== undefined)
         updateData.provider_use_current_date =
           req.body.provider_use_current_date;
+      if (req.body.provider_signature_date !== undefined) {
+        if (!isValidIsoDateOrNullish(req.body.provider_signature_date)) {
+          res.status(400).json({
+            success: false,
+            error: 'Invalid signature date',
+            message:
+              'La date de signature prestataire doit être au format YYYY-MM-DD',
+          });
+          return;
+        }
+        updateData.provider_signature_date =
+          req.body.provider_signature_date || null;
+      }
 
-      const updatedCRA = await CRAModel.update(id as string, updateData, userIdFilter);
+      const updatedCRA = await CRAModel.update(
+        id as string,
+        updateData,
+        userIdFilter,
+      );
 
       if (!updatedCRA) {
         res.status(404).json({

--- a/backend/src/models/cra.model.ts
+++ b/backend/src/models/cra.model.ts
@@ -41,11 +41,13 @@ export class CRAModel {
         client_signature_image,
         client_signature_location,
         client_use_current_date,
+        client_signature_date,
         provider_signatory_name,
         provider_signatory_title,
         provider_signature_image,
         provider_signature_location,
         provider_use_current_date,
+        provider_signature_date,
         created_at,
         updated_at
       FROM cras
@@ -122,11 +124,13 @@ export class CRAModel {
         client_signature_image,
         client_signature_location,
         client_use_current_date,
+        client_signature_date,
         provider_signatory_name,
         provider_signatory_title,
         provider_signature_image,
         provider_signature_location,
         provider_use_current_date,
+        provider_signature_date,
         created_at,
         updated_at
       FROM cras
@@ -164,13 +168,15 @@ export class CRAModel {
         client_signature_image,
         client_signature_location,
         client_use_current_date,
+        client_signature_date,
         provider_signatory_name,
         provider_signatory_title,
         provider_signature_image,
         provider_signature_location,
-        provider_use_current_date
+        provider_use_current_date,
+        provider_signature_date
       )
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)
       RETURNING
         id,
         user_id,
@@ -186,11 +192,13 @@ export class CRAModel {
         client_signature_image,
         client_signature_location,
         client_use_current_date,
+        client_signature_date,
         provider_signatory_name,
         provider_signatory_title,
         provider_signature_image,
         provider_signature_location,
         provider_use_current_date,
+        provider_signature_date,
         created_at,
         updated_at
     `;
@@ -209,11 +217,13 @@ export class CRAModel {
       data.client_signature_image || null,
       data.client_signature_location || null,
       data.client_use_current_date ?? null,
+      data.client_signature_date || null,
       data.provider_signatory_name || null,
       data.provider_signatory_title || null,
       data.provider_signature_image || null,
       data.provider_signature_location || null,
       data.provider_use_current_date ?? null,
+      data.provider_signature_date || null,
     ]);
 
     return result.rows[0];
@@ -222,7 +232,11 @@ export class CRAModel {
   /**
    * Met à jour un CRA existant
    */
-  static async update(id: string, data: UpdateCRAInput, userId?: string): Promise<CRA | null> {
+  static async update(
+    id: string,
+    data: UpdateCRAInput,
+    userId?: string,
+  ): Promise<CRA | null> {
     // Construire la requête de mise à jour dynamiquement
     const updates: string[] = [];
     const params: unknown[] = [];
@@ -300,6 +314,12 @@ export class CRAModel {
       paramIndex++;
     }
 
+    if (data.client_signature_date !== undefined) {
+      updates.push(`client_signature_date = $${paramIndex}`);
+      params.push(data.client_signature_date || null);
+      paramIndex++;
+    }
+
     if (data.provider_signatory_name !== undefined) {
       updates.push(`provider_signatory_name = $${paramIndex}`);
       params.push(data.provider_signatory_name || null);
@@ -327,6 +347,12 @@ export class CRAModel {
     if (data.provider_use_current_date !== undefined) {
       updates.push(`provider_use_current_date = $${paramIndex}`);
       params.push(data.provider_use_current_date);
+      paramIndex++;
+    }
+
+    if (data.provider_signature_date !== undefined) {
+      updates.push(`provider_signature_date = $${paramIndex}`);
+      params.push(data.provider_signature_date || null);
       paramIndex++;
     }
 
@@ -369,11 +395,13 @@ export class CRAModel {
         client_signature_image,
         client_signature_location,
         client_use_current_date,
+        client_signature_date,
         provider_signatory_name,
         provider_signatory_title,
         provider_signature_image,
         provider_signature_location,
         provider_use_current_date,
+        provider_signature_date,
         created_at,
         updated_at
     `;

--- a/backend/src/types/cra.types.ts
+++ b/backend/src/types/cra.types.ts
@@ -26,11 +26,13 @@ export interface CRA {
   client_signature_image?: string;
   client_signature_location?: string;
   client_use_current_date?: boolean;
+  client_signature_date?: Date | string | null;
   provider_signatory_name?: string;
   provider_signatory_title?: string;
   provider_signature_image?: string;
   provider_signature_location?: string;
   provider_use_current_date?: boolean;
+  provider_signature_date?: Date | string | null;
 
   created_at: Date;
   updated_at: Date;
@@ -52,11 +54,13 @@ export interface CreateCRAInput {
   client_signature_image?: string;
   client_signature_location?: string;
   client_use_current_date?: boolean;
+  client_signature_date?: string | null;
   provider_signatory_name?: string;
   provider_signatory_title?: string;
   provider_signature_image?: string;
   provider_signature_location?: string;
   provider_use_current_date?: boolean;
+  provider_signature_date?: string | null;
 }
 
 export interface UpdateCRAInput {
@@ -74,11 +78,13 @@ export interface UpdateCRAInput {
   client_signature_image?: string;
   client_signature_location?: string;
   client_use_current_date?: boolean;
+  client_signature_date?: string | null;
   provider_signatory_name?: string;
   provider_signatory_title?: string;
   provider_signature_image?: string;
   provider_signature_location?: string;
   provider_use_current_date?: boolean;
+  provider_signature_date?: string | null;
 }
 
 export interface CRAFilters {

--- a/src/components/pdf/CRAPDFDocument.tsx
+++ b/src/components/pdf/CRAPDFDocument.tsx
@@ -65,6 +65,10 @@ export function CRAPDFDocument({
 }: CRAPDFDocumentProps) {
   const workedDaysCount = cra.worked_days?.length || 0;
 
+  // Normalise une date reçue du backend (ISO timestamp ou YYYY-MM-DD) en YYYY-MM-DD
+  const toIsoDate = (raw?: string | null): string | undefined =>
+    raw ? raw.substring(0, 10) : undefined;
+
   // Récupérer les signatures (CRA override ou défaut company)
   const clientSignature = {
     name: cra.client_signatory_name || clientCompany.default_signatory_name,
@@ -74,6 +78,7 @@ export function CRAPDFDocument({
       cra.client_signature_location || clientCompany.default_signature_location,
     useCurrentDate:
       cra.client_use_current_date ?? clientCompany.default_use_current_date,
+    signatureDate: toIsoDate(cra.client_signature_date),
   };
 
   const providerSignature = {
@@ -87,6 +92,7 @@ export function CRAPDFDocument({
       providerCompany.default_signature_location,
     useCurrentDate:
       cra.provider_use_current_date ?? providerCompany.default_use_current_date,
+    signatureDate: toIsoDate(cra.provider_signature_date),
   };
 
   return (

--- a/src/components/pdf/PDFSignatures.tsx
+++ b/src/components/pdf/PDFSignatures.tsx
@@ -26,8 +26,10 @@ interface SignatureInfo {
   image?: string;
   /** Lieu de signature (ville) */
   location?: string;
-  /** Utiliser la date courante */
+  /** Utiliser la date courante (jour de la génération) */
   useCurrentDate?: boolean;
+  /** Date fixe (YYYY-MM-DD). Prime sur useCurrentDate si présente. */
+  signatureDate?: string;
 }
 
 interface PDFSignaturesProps {
@@ -54,8 +56,12 @@ function getSignatureImageUrl(path?: string): string | null {
 /**
  * Vérifie si les champs lieu/date sont vides (nécessitant un remplissage manuel)
  */
-function isManualEntry(location?: string, useCurrentDate?: boolean): boolean {
-  return !location && !useCurrentDate;
+function isManualEntry(
+  location?: string,
+  useCurrentDate?: boolean,
+  signatureDate?: string,
+): boolean {
+  return !location && !useCurrentDate && !signatureDate;
 }
 
 /**
@@ -70,11 +76,27 @@ function formatFaitALocation(location?: string): string {
 
 /**
  * Formate la ligne "le <DATE>"
+ *
+ * Trois cas :
+ * - signatureDate fournie (YYYY-MM-DD) → date fixe formatée en fr-FR
+ * - useCurrentDate true → date du jour à la génération
+ * - sinon → champ vide à remplir à la main
  */
-function formatFaitADate(useCurrentDate?: boolean): string {
-  const datePart = useCurrentDate
-    ? new Date().toLocaleDateString('fr-FR')
-    : '____/____/_______';
+function formatFaitADate(
+  useCurrentDate?: boolean,
+  signatureDate?: string,
+): string {
+  let datePart: string;
+  if (signatureDate) {
+    // 'T00:00:00' évite les décalages de timezone (la date civile reste celle saisie)
+    datePart = new Date(signatureDate + 'T00:00:00').toLocaleDateString(
+      'fr-FR',
+    );
+  } else if (useCurrentDate) {
+    datePart = new Date().toLocaleDateString('fr-FR');
+  } else {
+    datePart = '____/____/_______';
+  }
   return `le ${datePart}`;
 }
 
@@ -117,19 +139,26 @@ export function PDFSignatures({
               {isManualEntry(
                 providerSignature.location,
                 providerSignature.useCurrentDate,
+                providerSignature.signatureDate,
               ) ? (
                 <>
                   <Text style={pdfStyles.faitAEmpty}>
                     {formatFaitALocation(providerSignature.location)}
                   </Text>
                   <Text style={pdfStyles.faitAEmptyDate}>
-                    {formatFaitADate(providerSignature.useCurrentDate)}
+                    {formatFaitADate(
+                      providerSignature.useCurrentDate,
+                      providerSignature.signatureDate,
+                    )}
                   </Text>
                 </>
               ) : (
                 <Text style={pdfStyles.faitA}>
                   {formatFaitALocation(providerSignature.location)}{' '}
-                  {formatFaitADate(providerSignature.useCurrentDate)}
+                  {formatFaitADate(
+                    providerSignature.useCurrentDate,
+                    providerSignature.signatureDate,
+                  )}
                 </Text>
               )}
               <Text style={pdfStyles.luEtApprouvePlaceholder}>
@@ -175,19 +204,26 @@ export function PDFSignatures({
               {isManualEntry(
                 clientSignature.location,
                 clientSignature.useCurrentDate,
+                clientSignature.signatureDate,
               ) ? (
                 <>
                   <Text style={pdfStyles.faitAEmpty}>
                     {formatFaitALocation(clientSignature.location)}
                   </Text>
                   <Text style={pdfStyles.faitAEmptyDate}>
-                    {formatFaitADate(clientSignature.useCurrentDate)}
+                    {formatFaitADate(
+                      clientSignature.useCurrentDate,
+                      clientSignature.signatureDate,
+                    )}
                   </Text>
                 </>
               ) : (
                 <Text style={pdfStyles.faitA}>
                   {formatFaitALocation(clientSignature.location)}{' '}
-                  {formatFaitADate(clientSignature.useCurrentDate)}
+                  {formatFaitADate(
+                    clientSignature.useCurrentDate,
+                    clientSignature.signatureDate,
+                  )}
                 </Text>
               )}
               <Text style={pdfStyles.luEtApprouvePlaceholder}>

--- a/src/components/ui/SignatureInput.tsx
+++ b/src/components/ui/SignatureInput.tsx
@@ -1,8 +1,17 @@
 import { useState, useRef, ChangeEvent } from 'react';
 import { Input } from './Input';
 import { Button } from './Button';
+import { DatePicker } from './DatePicker';
 import { uploadSignature } from '@/services/upload.service';
 import { SignatureData } from '@/types/cra.types';
+
+type SignatureDateMode = 'auto' | 'fixed' | 'empty';
+
+function getDateMode(value: Partial<SignatureData>): SignatureDateMode {
+  if (value.signatureDate) return 'fixed';
+  if (value.useCurrentDate) return 'auto';
+  return 'empty';
+}
 
 export interface SignatureInputProps {
   label: string;
@@ -73,6 +82,7 @@ export function SignatureInput({
       signatureImage: '',
       signatureLocation: '',
       useCurrentDate: false,
+      signatureDate: undefined,
     });
     setUploadError(null);
   };
@@ -85,9 +95,30 @@ export function SignatureInput({
         signatureImage: defaultSignature.signatureImage || '',
         signatureLocation: defaultSignature.signatureLocation || '',
         useCurrentDate: defaultSignature.useCurrentDate ?? false,
+        signatureDate: defaultSignature.signatureDate,
       });
     }
   };
+
+  const handleDateModeChange = (mode: SignatureDateMode) => {
+    if (mode === 'auto') {
+      onChange({ ...value, useCurrentDate: true, signatureDate: undefined });
+    } else if (mode === 'fixed') {
+      // Pré-remplir avec aujourd'hui : une valeur truthy est nécessaire pour
+      // que getDateMode renvoie 'fixed' au prochain render (sinon le mapping
+      // `|| undefined` côté pages CRA retransforme '' en undefined → 'empty').
+      const today = new Date().toISOString().substring(0, 10);
+      onChange({
+        ...value,
+        useCurrentDate: false,
+        signatureDate: value.signatureDate || today,
+      });
+    } else {
+      onChange({ ...value, useCurrentDate: false, signatureDate: undefined });
+    }
+  };
+
+  const dateMode = getDateMode(value);
 
   const getImageUrl = (imageData?: string) => {
     if (!imageData) return null;
@@ -101,13 +132,15 @@ export function SignatureInput({
     value.signatoryTitle ||
     value.signatureImage ||
     value.signatureLocation ||
-    value.useCurrentDate;
+    value.useCurrentDate ||
+    value.signatureDate;
   const hasDefault =
     defaultSignature?.signatoryName ||
     defaultSignature?.signatoryTitle ||
     defaultSignature?.signatureImage ||
     defaultSignature?.signatureLocation ||
-    defaultSignature?.useCurrentDate;
+    defaultSignature?.useCurrentDate ||
+    defaultSignature?.signatureDate;
 
   return (
     <div className="flex flex-col gap-4 p-4 border border-[rgb(var(--color-border))] rounded-lg bg-[rgb(var(--color-surface))]">
@@ -178,21 +211,71 @@ export function SignatureInput({
         fullWidth
       />
 
-      {/* Utiliser la date du jour */}
-      <label className="flex items-center gap-3 cursor-pointer">
-        <input
-          type="checkbox"
-          checked={value.useCurrentDate || false}
-          onChange={(e) =>
-            onChange({ ...value, useCurrentDate: e.target.checked })
-          }
-          disabled={disabled}
-          className="w-4 h-4 rounded border-[rgb(var(--color-border))] text-[rgb(var(--color-primary))] focus:ring-[rgb(var(--color-primary))]"
-        />
-        <span className="text-sm text-[rgb(var(--color-text))]">
-          Utiliser la date du jour à la génération du PDF
-        </span>
-      </label>
+      {/* Date de signature : Auto / Fixe / Vide */}
+      <fieldset className="flex flex-col gap-2">
+        <legend className="text-sm font-medium text-[rgb(var(--color-text))] mb-1">
+          Date de signature
+        </legend>
+
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="radio"
+            name={`signature-date-mode-${label}`}
+            checked={dateMode === 'auto'}
+            onChange={() => handleDateModeChange('auto')}
+            disabled={disabled}
+            className="w-4 h-4 border-[rgb(var(--color-border))] text-[rgb(var(--color-primary))] focus:ring-[rgb(var(--color-primary))]"
+          />
+          <span className="text-sm text-[rgb(var(--color-text))]">
+            Date du jour à la génération du PDF
+          </span>
+        </label>
+
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="radio"
+            name={`signature-date-mode-${label}`}
+            checked={dateMode === 'fixed'}
+            onChange={() => handleDateModeChange('fixed')}
+            disabled={disabled}
+            className="w-4 h-4 border-[rgb(var(--color-border))] text-[rgb(var(--color-primary))] focus:ring-[rgb(var(--color-primary))]"
+          />
+          <span className="text-sm text-[rgb(var(--color-text))]">
+            Date fixe
+          </span>
+        </label>
+
+        {dateMode === 'fixed' && (
+          <div className="ml-7">
+            <DatePicker
+              value={value.signatureDate || ''}
+              onChange={(e) =>
+                onChange({
+                  ...value,
+                  useCurrentDate: false,
+                  signatureDate: e.target.value || '',
+                })
+              }
+              disabled={disabled}
+              helperText="Cette date apparaîtra telle quelle dans le PDF"
+            />
+          </div>
+        )}
+
+        <label className="flex items-center gap-3 cursor-pointer">
+          <input
+            type="radio"
+            name={`signature-date-mode-${label}`}
+            checked={dateMode === 'empty'}
+            onChange={() => handleDateModeChange('empty')}
+            disabled={disabled}
+            className="w-4 h-4 border-[rgb(var(--color-border))] text-[rgb(var(--color-primary))] focus:ring-[rgb(var(--color-primary))]"
+          />
+          <span className="text-sm text-[rgb(var(--color-text))]">
+            Laisser vide (à remplir manuellement)
+          </span>
+        </label>
+      </fieldset>
 
       {/* Upload d'image */}
       <div className="flex flex-col gap-2">

--- a/src/pages/CreateCRA.tsx
+++ b/src/pages/CreateCRA.tsx
@@ -136,11 +136,13 @@ export function CreateCRA() {
         client_signature_image: data.client_signature_image,
         client_signature_location: data.client_signature_location,
         client_use_current_date: data.client_use_current_date,
+        client_signature_date: data.client_signature_date || null,
         provider_signatory_name: data.provider_signatory_name,
         provider_signatory_title: data.provider_signatory_title,
         provider_signature_image: data.provider_signature_image,
         provider_signature_location: data.provider_signature_location,
         provider_use_current_date: data.provider_use_current_date,
+        provider_signature_date: data.provider_signature_date || null,
       });
 
       addNotification('CRA créé avec succès', 'success');
@@ -392,27 +394,39 @@ export function CreateCRA() {
                               name="client_use_current_date"
                               control={control}
                               render={({ field: dateField }) => (
-                                <SignatureInput
-                                  label={`Signature ${clientCompany?.designation || 'Client'}`}
-                                  value={{
-                                    signatoryName: nameField.value || '',
-                                    signatoryTitle: titleField.value || '',
-                                    signatureImage: imageField.value || '',
-                                    signatureLocation:
-                                      locationField.value || '',
-                                    useCurrentDate: dateField.value ?? false,
-                                  }}
-                                  onChange={(sig) => {
-                                    nameField.onChange(sig.signatoryName);
-                                    titleField.onChange(sig.signatoryTitle);
-                                    imageField.onChange(sig.signatureImage);
-                                    locationField.onChange(
-                                      sig.signatureLocation,
-                                    );
-                                    dateField.onChange(sig.useCurrentDate);
-                                  }}
-                                  defaultSignature={clientDefaultSignature}
-                                  disabled={!selectedClientId}
+                                <Controller
+                                  name="client_signature_date"
+                                  control={control}
+                                  render={({ field: fixedDateField }) => (
+                                    <SignatureInput
+                                      label={`Signature ${clientCompany?.designation || 'Client'}`}
+                                      value={{
+                                        signatoryName: nameField.value || '',
+                                        signatoryTitle: titleField.value || '',
+                                        signatureImage: imageField.value || '',
+                                        signatureLocation:
+                                          locationField.value || '',
+                                        useCurrentDate:
+                                          dateField.value ?? false,
+                                        signatureDate:
+                                          fixedDateField.value || undefined,
+                                      }}
+                                      onChange={(sig) => {
+                                        nameField.onChange(sig.signatoryName);
+                                        titleField.onChange(sig.signatoryTitle);
+                                        imageField.onChange(sig.signatureImage);
+                                        locationField.onChange(
+                                          sig.signatureLocation,
+                                        );
+                                        dateField.onChange(sig.useCurrentDate);
+                                        fixedDateField.onChange(
+                                          sig.signatureDate || '',
+                                        );
+                                      }}
+                                      defaultSignature={clientDefaultSignature}
+                                      disabled={!selectedClientId}
+                                    />
+                                  )}
                                 />
                               )}
                             />
@@ -446,27 +460,41 @@ export function CreateCRA() {
                               name="provider_use_current_date"
                               control={control}
                               render={({ field: dateField }) => (
-                                <SignatureInput
-                                  label={`Signature ${providerCompany?.designation || 'Prestataire'}`}
-                                  value={{
-                                    signatoryName: nameField.value || '',
-                                    signatoryTitle: titleField.value || '',
-                                    signatureImage: imageField.value || '',
-                                    signatureLocation:
-                                      locationField.value || '',
-                                    useCurrentDate: dateField.value ?? false,
-                                  }}
-                                  onChange={(sig) => {
-                                    nameField.onChange(sig.signatoryName);
-                                    titleField.onChange(sig.signatoryTitle);
-                                    imageField.onChange(sig.signatureImage);
-                                    locationField.onChange(
-                                      sig.signatureLocation,
-                                    );
-                                    dateField.onChange(sig.useCurrentDate);
-                                  }}
-                                  defaultSignature={providerDefaultSignature}
-                                  disabled={!selectedProviderId}
+                                <Controller
+                                  name="provider_signature_date"
+                                  control={control}
+                                  render={({ field: fixedDateField }) => (
+                                    <SignatureInput
+                                      label={`Signature ${providerCompany?.designation || 'Prestataire'}`}
+                                      value={{
+                                        signatoryName: nameField.value || '',
+                                        signatoryTitle: titleField.value || '',
+                                        signatureImage: imageField.value || '',
+                                        signatureLocation:
+                                          locationField.value || '',
+                                        useCurrentDate:
+                                          dateField.value ?? false,
+                                        signatureDate:
+                                          fixedDateField.value || undefined,
+                                      }}
+                                      onChange={(sig) => {
+                                        nameField.onChange(sig.signatoryName);
+                                        titleField.onChange(sig.signatoryTitle);
+                                        imageField.onChange(sig.signatureImage);
+                                        locationField.onChange(
+                                          sig.signatureLocation,
+                                        );
+                                        dateField.onChange(sig.useCurrentDate);
+                                        fixedDateField.onChange(
+                                          sig.signatureDate || '',
+                                        );
+                                      }}
+                                      defaultSignature={
+                                        providerDefaultSignature
+                                      }
+                                      disabled={!selectedProviderId}
+                                    />
+                                  )}
                                 />
                               )}
                             />
@@ -526,7 +554,9 @@ export function CreateCRA() {
                 <p className="font-bold mb-1 text-[rgb(var(--color-text))]">
                   Erreur lors de la création
                 </p>
-                <p className="text-sm text-[rgb(var(--color-text-secondary))]">{submitError}</p>
+                <p className="text-sm text-[rgb(var(--color-text-secondary))]">
+                  {submitError}
+                </p>
               </div>
             </div>
           </div>

--- a/src/pages/EditCRA.tsx
+++ b/src/pages/EditCRA.tsx
@@ -32,6 +32,11 @@ export function EditCRA() {
   const { id } = useParams<{ id: string }>();
 
   const { cra: selectedCRA, isLoading, error } = useCRA(id);
+
+  // Normalise une date reçue du backend (ISO timestamp ou YYYY-MM-DD) en YYYY-MM-DD
+  const toIsoDate = (raw?: string | null): string =>
+    raw ? raw.substring(0, 10) : '';
+
   const updateCRA = useCRAStore((state) => state.updateCRA);
   const deleteCRA = useCRAStore((state) => state.deleteCRA);
   const companies = useCompanyStore((state) => state.companies);
@@ -71,6 +76,7 @@ export function EditCRA() {
           client_signature_location:
             selectedCRA.client_signature_location || '',
           client_use_current_date: selectedCRA.client_use_current_date ?? false,
+          client_signature_date: toIsoDate(selectedCRA.client_signature_date),
           provider_signatory_name: selectedCRA.provider_signatory_name || '',
           provider_signatory_title: selectedCRA.provider_signatory_title || '',
           provider_signature_image: selectedCRA.provider_signature_image || '',
@@ -78,6 +84,9 @@ export function EditCRA() {
             selectedCRA.provider_signature_location || '',
           provider_use_current_date:
             selectedCRA.provider_use_current_date ?? false,
+          provider_signature_date: toIsoDate(
+            selectedCRA.provider_signature_date,
+          ),
         }
       : {},
   );
@@ -98,6 +107,7 @@ export function EditCRA() {
         client_signature_image: selectedCRA.client_signature_image || '',
         client_signature_location: selectedCRA.client_signature_location || '',
         client_use_current_date: selectedCRA.client_use_current_date ?? false,
+        client_signature_date: toIsoDate(selectedCRA.client_signature_date),
         provider_signatory_name: selectedCRA.provider_signatory_name || '',
         provider_signatory_title: selectedCRA.provider_signatory_title || '',
         provider_signature_image: selectedCRA.provider_signature_image || '',
@@ -105,6 +115,7 @@ export function EditCRA() {
           selectedCRA.provider_signature_location || '',
         provider_use_current_date:
           selectedCRA.provider_use_current_date ?? false,
+        provider_signature_date: toIsoDate(selectedCRA.provider_signature_date),
       });
     }
   }, [selectedCRA, reset]);
@@ -204,11 +215,13 @@ export function EditCRA() {
         client_signature_image: data.client_signature_image || null,
         client_signature_location: data.client_signature_location || null,
         client_use_current_date: data.client_use_current_date ?? null,
+        client_signature_date: data.client_signature_date || null,
         provider_signatory_name: data.provider_signatory_name || null,
         provider_signatory_title: data.provider_signatory_title || null,
         provider_signature_image: data.provider_signature_image || null,
         provider_signature_location: data.provider_signature_location || null,
         provider_use_current_date: data.provider_use_current_date ?? null,
+        provider_signature_date: data.provider_signature_date || null,
       });
 
       addNotification('CRA mis à jour avec succès', 'success');
@@ -551,27 +564,39 @@ export function EditCRA() {
                               name="client_use_current_date"
                               control={control}
                               render={({ field: dateField }) => (
-                                <SignatureInput
-                                  label={`Signature ${clientCompany?.designation || 'Client'}`}
-                                  value={{
-                                    signatoryName: nameField.value || '',
-                                    signatoryTitle: titleField.value || '',
-                                    signatureImage: imageField.value || '',
-                                    signatureLocation:
-                                      locationField.value || '',
-                                    useCurrentDate: dateField.value ?? false,
-                                  }}
-                                  onChange={(sig) => {
-                                    nameField.onChange(sig.signatoryName);
-                                    titleField.onChange(sig.signatoryTitle);
-                                    imageField.onChange(sig.signatureImage);
-                                    locationField.onChange(
-                                      sig.signatureLocation,
-                                    );
-                                    dateField.onChange(sig.useCurrentDate);
-                                  }}
-                                  defaultSignature={clientDefaultSignature}
-                                  disabled={!selectedClientId}
+                                <Controller
+                                  name="client_signature_date"
+                                  control={control}
+                                  render={({ field: fixedDateField }) => (
+                                    <SignatureInput
+                                      label={`Signature ${clientCompany?.designation || 'Client'}`}
+                                      value={{
+                                        signatoryName: nameField.value || '',
+                                        signatoryTitle: titleField.value || '',
+                                        signatureImage: imageField.value || '',
+                                        signatureLocation:
+                                          locationField.value || '',
+                                        useCurrentDate:
+                                          dateField.value ?? false,
+                                        signatureDate:
+                                          fixedDateField.value || undefined,
+                                      }}
+                                      onChange={(sig) => {
+                                        nameField.onChange(sig.signatoryName);
+                                        titleField.onChange(sig.signatoryTitle);
+                                        imageField.onChange(sig.signatureImage);
+                                        locationField.onChange(
+                                          sig.signatureLocation,
+                                        );
+                                        dateField.onChange(sig.useCurrentDate);
+                                        fixedDateField.onChange(
+                                          sig.signatureDate || '',
+                                        );
+                                      }}
+                                      defaultSignature={clientDefaultSignature}
+                                      disabled={!selectedClientId}
+                                    />
+                                  )}
                                 />
                               )}
                             />
@@ -605,27 +630,41 @@ export function EditCRA() {
                               name="provider_use_current_date"
                               control={control}
                               render={({ field: dateField }) => (
-                                <SignatureInput
-                                  label={`Signature ${providerCompany?.designation || 'Prestataire'}`}
-                                  value={{
-                                    signatoryName: nameField.value || '',
-                                    signatoryTitle: titleField.value || '',
-                                    signatureImage: imageField.value || '',
-                                    signatureLocation:
-                                      locationField.value || '',
-                                    useCurrentDate: dateField.value ?? false,
-                                  }}
-                                  onChange={(sig) => {
-                                    nameField.onChange(sig.signatoryName);
-                                    titleField.onChange(sig.signatoryTitle);
-                                    imageField.onChange(sig.signatureImage);
-                                    locationField.onChange(
-                                      sig.signatureLocation,
-                                    );
-                                    dateField.onChange(sig.useCurrentDate);
-                                  }}
-                                  defaultSignature={providerDefaultSignature}
-                                  disabled={!selectedProviderId}
+                                <Controller
+                                  name="provider_signature_date"
+                                  control={control}
+                                  render={({ field: fixedDateField }) => (
+                                    <SignatureInput
+                                      label={`Signature ${providerCompany?.designation || 'Prestataire'}`}
+                                      value={{
+                                        signatoryName: nameField.value || '',
+                                        signatoryTitle: titleField.value || '',
+                                        signatureImage: imageField.value || '',
+                                        signatureLocation:
+                                          locationField.value || '',
+                                        useCurrentDate:
+                                          dateField.value ?? false,
+                                        signatureDate:
+                                          fixedDateField.value || undefined,
+                                      }}
+                                      onChange={(sig) => {
+                                        nameField.onChange(sig.signatoryName);
+                                        titleField.onChange(sig.signatoryTitle);
+                                        imageField.onChange(sig.signatureImage);
+                                        locationField.onChange(
+                                          sig.signatureLocation,
+                                        );
+                                        dateField.onChange(sig.useCurrentDate);
+                                        fixedDateField.onChange(
+                                          sig.signatureDate || '',
+                                        );
+                                      }}
+                                      defaultSignature={
+                                        providerDefaultSignature
+                                      }
+                                      disabled={!selectedProviderId}
+                                    />
+                                  )}
                                 />
                               )}
                             />

--- a/src/schemas/cra.schema.ts
+++ b/src/schemas/cra.schema.ts
@@ -86,11 +86,21 @@ const craFormBaseSchema = z.object({
   client_signature_image: z.string().optional(),
   client_signature_location: z.string().max(255).optional(),
   client_use_current_date: z.boolean().optional(),
+  client_signature_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date invalide (format YYYY-MM-DD attendu)')
+    .or(z.literal(''))
+    .optional(),
   provider_signatory_name: z.string().max(255).optional(),
   provider_signatory_title: z.string().max(255).optional(),
   provider_signature_image: z.string().optional(),
   provider_signature_location: z.string().max(255).optional(),
   provider_use_current_date: z.boolean().optional(),
+  provider_signature_date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'Date invalide (format YYYY-MM-DD attendu)')
+    .or(z.literal(''))
+    .optional(),
 });
 
 /**

--- a/src/types/cra.types.ts
+++ b/src/types/cra.types.ts
@@ -23,11 +23,13 @@ export interface CRA {
   client_signature_image?: string;
   client_signature_location?: string;
   client_use_current_date?: boolean;
+  client_signature_date?: string | null; // Date fixe de signature client (YYYY-MM-DD ou ISO)
   provider_signatory_name?: string;
   provider_signatory_title?: string;
   provider_signature_image?: string;
   provider_signature_location?: string;
   provider_use_current_date?: boolean;
+  provider_signature_date?: string | null; // Date fixe de signature prestataire (YYYY-MM-DD ou ISO)
 
   created_at: string; // Format ISO 8601
   updated_at: string; // Format ISO 8601
@@ -51,11 +53,13 @@ export type CreateCRAInput = {
   client_signature_image?: string;
   client_signature_location?: string;
   client_use_current_date?: boolean;
+  client_signature_date?: string | null;
   provider_signatory_name?: string;
   provider_signatory_title?: string;
   provider_signature_image?: string;
   provider_signature_location?: string;
   provider_use_current_date?: boolean;
+  provider_signature_date?: string | null;
 };
 
 /**
@@ -77,11 +81,13 @@ export type UpdateCRAInput = {
   client_signature_image?: string | null;
   client_signature_location?: string | null;
   client_use_current_date?: boolean | null;
+  client_signature_date?: string | null;
   provider_signatory_name?: string | null;
   provider_signatory_title?: string | null;
   provider_signature_image?: string | null;
   provider_signature_location?: string | null;
   provider_use_current_date?: boolean | null;
+  provider_signature_date?: string | null;
 };
 
 /**
@@ -114,5 +120,6 @@ export interface SignatureData {
   signatoryTitle: string; // Titre/fonction du signataire
   signatureImage: string; // Chemin ou URL de l'image de signature
   signatureLocation?: string; // Lieu de signature (ville)
-  useCurrentDate?: boolean; // Utiliser la date du jour
+  useCurrentDate?: boolean; // Utiliser la date du jour à la génération du PDF
+  signatureDate?: string; // Date fixe de signature (YYYY-MM-DD). Si présente, prime sur useCurrentDate.
 }

--- a/start-dev.sh
+++ b/start-dev.sh
@@ -103,7 +103,18 @@ if [ "$TABLE_EXISTS" = "f" ]; then
         exit 1
     fi
 else
-    log_warning "Database tables already exist. Skipping initialization."
+    log_warning "Database tables already exist. Skipping schema initialization."
+fi
+
+# Appliquer les migrations incrémentales (idempotent, safe à chaque démarrage).
+# Sur une DB fraîchement initialisée : applique toutes les migrations NNN_*.sql.
+# Sur une DB existante : bootstrap auto puis applique uniquement les nouvelles.
+log_info "Applying pending migrations..."
+if bash backend/migrations/migrate.sh; then
+    log_success "Database migrations up-to-date"
+else
+    log_error "Failed to apply migrations"
+    exit 1
 fi
 
 # Installation des dépendances


### PR DESCRIPTION
Signature date now has three modes (auto / fixed / empty) editable per CRA side (client and provider independently), instead of just the today-or-blank toggle. Fixed mode stores a YYYY-MM-DD in two new DATE columns and renders that date verbatim in the PDF.

Adds an idempotent migration runner so future schema changes ship as NNN_*.sql files that apply themselves at ./start-dev.sh — with auto-bootstrap of the tracking table so switching branches on an existing DB just works.